### PR TITLE
[DAP-5266] Add multisharded multicolumn vindex

### DIFF
--- a/go/vt/vtgate/vindexes/hybrid.go
+++ b/go/vt/vtgate/vindexes/hybrid.go
@@ -27,7 +27,8 @@ import (
 )
 
 var (
-	_ SingleColumn = (*Hybrid)(nil)
+	_              SingleColumn = (*Hybrid)(nil)
+	hybridVindexes              = make(map[string]SingleColumn)
 )
 
 func init() {
@@ -84,6 +85,7 @@ func NewHybrid(name string, m map[string]string) (Vindex, error) {
 	}
 	h.vindexB = vindexB.(SingleColumn)
 
+	hybridVindexes[name] = h
 	return h, nil
 }
 

--- a/go/vt/vtgate/vindexes/hybrid.go
+++ b/go/vt/vtgate/vindexes/hybrid.go
@@ -85,6 +85,7 @@ func NewHybrid(name string, m map[string]string) (Vindex, error) {
 	}
 	h.vindexB = vindexB.(SingleColumn)
 
+	// store this vindex so it can be referenced in other vindexes
 	hybridVindexes[name] = h
 	return h, nil
 }

--- a/go/vt/vtgate/vindexes/hybrid_test.go
+++ b/go/vt/vtgate/vindexes/hybrid_test.go
@@ -38,7 +38,7 @@ func TestHybridInfo(t *testing.T) {
 	assert.Equal(t, "etsy_hybrid_a_hash", hybridHashReverseThreshold.(*Hybrid).vindexA.String())
 	assert.Equal(t, "etsy_hybrid_b_reverse_bits", hybridHashReverseThreshold.(*Hybrid).vindexB.String())
 	assert.Equal(t, uint64(5), hybridHashReverseThreshold.(*Hybrid).threshold)
-	assert.Equal(t, map[string]SingleColumn{"etsy_hybrid": hybridHashReverse}, hybridVindexes)
+	assert.Equal(t, map[string]SingleColumn{"etsy_hybrid": hybridHashReverseThreshold}, hybridVindexes)
 
 	hybridHashReverseFallback := createHybridWithFallback("hash", "reverse_bits", map[string]string{}, t)
 	assert.Equal(t, 1, hybridHashReverseFallback.Cost())
@@ -73,7 +73,7 @@ func TestHybridInfo(t *testing.T) {
 	assert.Equal(t, "etsy_hybrid_a_etsy_sqlite_lookup_unique", hybridSqliteHashFallback.(*Hybrid).vindexA.String())
 	assert.Equal(t, "etsy_hybrid_b_hash", hybridSqliteHashFallback.(*Hybrid).vindexB.String())
 	assert.Equal(t, uint64(0), hybridSqliteHashFallback.(*Hybrid).threshold)
-	assert.Equal(t, map[string]SingleColumn{"etsy_hybrid": hybridSqliteHash}, hybridVindexes)
+	assert.Equal(t, map[string]SingleColumn{"etsy_hybrid": hybridSqliteHashFallback}, hybridVindexes)
 }
 
 // Ensure that the Vindex correctly maps ids to destinations

--- a/go/vt/vtgate/vindexes/hybrid_test.go
+++ b/go/vt/vtgate/vindexes/hybrid_test.go
@@ -38,6 +38,7 @@ func TestHybridInfo(t *testing.T) {
 	assert.Equal(t, "etsy_hybrid_a_hash", hybridHashReverseThreshold.(*Hybrid).vindexA.String())
 	assert.Equal(t, "etsy_hybrid_b_reverse_bits", hybridHashReverseThreshold.(*Hybrid).vindexB.String())
 	assert.Equal(t, uint64(5), hybridHashReverseThreshold.(*Hybrid).threshold)
+	assert.Equal(t, map[string]SingleColumn{"etsy_hybrid": hybridHashReverse}, hybridVindexes)
 
 	hybridHashReverseFallback := createHybridWithFallback("hash", "reverse_bits", map[string]string{}, t)
 	assert.Equal(t, 1, hybridHashReverseFallback.Cost())
@@ -72,6 +73,7 @@ func TestHybridInfo(t *testing.T) {
 	assert.Equal(t, "etsy_hybrid_a_etsy_sqlite_lookup_unique", hybridSqliteHashFallback.(*Hybrid).vindexA.String())
 	assert.Equal(t, "etsy_hybrid_b_hash", hybridSqliteHashFallback.(*Hybrid).vindexB.String())
 	assert.Equal(t, uint64(0), hybridSqliteHashFallback.(*Hybrid).threshold)
+	assert.Equal(t, map[string]SingleColumn{"etsy_hybrid": hybridSqliteHash}, hybridVindexes)
 }
 
 // Ensure that the Vindex correctly maps ids to destinations

--- a/go/vt/vtgate/vindexes/multisharded.go
+++ b/go/vt/vtgate/vindexes/multisharded.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vindexes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/key"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
+)
+
+var _ MultiColumn = (*MultiSharded)(nil)
+
+func init() {
+	Register("etsy_multisharded", NewMultiSharded)
+}
+
+type MultiSharded struct {
+	name               string
+	typeIdToVindexName map[string]string
+	subvindexMap       map[string]SingleColumn
+}
+
+func NewMultiSharded(name string, m map[string]string) (Vindex, error) {
+
+	var typeIdToVindexName map[string]string
+	err := json.Unmarshal([]byte(m["owner_type_to_vindex"]), &typeIdToVindexName)
+	if err != nil {
+		return nil, err
+	}
+
+	subvindexMap := make(map[string]SingleColumn)
+	for _, vindexName := range typeIdToVindexName {
+		if _, ok := hybridVindexes[vindexName]; ok {
+			subvindexMap[vindexName] = hybridVindexes[vindexName]
+		}
+	}
+
+	return &MultiSharded{
+		name:               name,
+		typeIdToVindexName: typeIdToVindexName,
+		subvindexMap:       subvindexMap,
+	}, nil
+}
+
+func (m *MultiSharded) String() string {
+	return m.name
+}
+
+func (m *MultiSharded) Cost() int {
+	cost := 0
+	for _, subvindex := range m.subvindexMap {
+		if subvindex == nil {
+			continue
+		}
+		subvindexCost := subvindex.Cost()
+		if subvindexCost > cost {
+			cost = subvindexCost
+		}
+	}
+	return cost
+}
+
+func (m *MultiSharded) IsUnique() bool {
+	for _, subvindex := range m.subvindexMap {
+		if subvindex == nil {
+			continue
+		}
+
+		if !subvindex.IsUnique() {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *MultiSharded) NeedsVCursor() bool {
+	for _, subvindex := range m.subvindexMap {
+		if subvindex == nil {
+			continue
+		}
+
+		if subvindex.NeedsVCursor() {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MultiSharded) PartialVindex() bool {
+	return false
+}
+
+func (m *MultiSharded) Map(ctx context.Context, vcursor VCursor, rowsColValues [][]sqltypes.Value) ([]key.Destination, error) {
+	out := make([]key.Destination, len(rowsColValues))
+	subvindexToRowsColValues, _, err := m.separateBySubvindex(rowsColValues, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	subvindexToResult := make(map[string][]key.Destination)
+	for subvindexName, colValues := range subvindexToRowsColValues {
+		ids := make([]sqltypes.Value, 0, len(colValues))
+		for _, colValue := range colValues {
+			ids = append(ids, colValue[1])
+		}
+		res, err := m.subvindexMap[subvindexName].Map(ctx, vcursor, ids)
+		if err != nil {
+			return nil, err
+		}
+
+		subvindexToResult[subvindexName] = res
+	}
+
+	// ensure results are in same order as rowsColsValues
+	subvindexToIndex := make(map[string]int)
+	for subvindex := range subvindexToResult {
+		subvindexToIndex[subvindex] = 0
+	}
+
+	for i, colValues := range rowsColValues {
+		found := false
+		typeIdString := colValues[0].ToString()
+		idString := colValues[1].ToString()
+
+		for subvindex, subvindexRowsColValues := range subvindexToRowsColValues {
+			idx := subvindexToIndex[subvindex]
+			if idx >= len(subvindexToRowsColValues[subvindex]) {
+				continue
+			}
+			subvindexColValues := subvindexRowsColValues[idx]
+			if typeIdString == subvindexColValues[0].ToString() && idString == subvindexColValues[1].ToString() {
+				res := subvindexToResult[subvindex][idx]
+				out[i] = res
+				subvindexToIndex[subvindex]++
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return nil, fmt.Errorf("MultiSharded.Map: no result found for input column values %v", colValues)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *MultiSharded) Verify(ctx context.Context, vcursor VCursor, rowsColValues [][]sqltypes.Value, ksids [][]byte) ([]bool, error) {
+	out := make([]bool, len(rowsColValues))
+
+	subvindexToRowsColValues, subvindexToKsids, err := m.separateBySubvindex(rowsColValues, ksids)
+	if err != nil {
+		return nil, err
+	}
+
+	subvindexToResult := make(map[string][]bool)
+	for subvindexName, colValues := range subvindexToRowsColValues {
+		ids := make([]sqltypes.Value, 0, len(colValues))
+		subvindexKsids := subvindexToKsids[subvindexName]
+		for _, colValue := range colValues {
+			ids = append(ids, colValue[1])
+		}
+		res, err := m.subvindexMap[subvindexName].Verify(ctx, vcursor, ids, subvindexKsids)
+		if err != nil {
+			return nil, err
+		}
+
+		subvindexToResult[subvindexName] = res
+	}
+
+	// ensure results are in same order as rowsColsValues & ksids
+	subvindexToIndex := make(map[string]int)
+	for subvindexName := range subvindexToResult {
+		subvindexToIndex[subvindexName] = 0
+	}
+
+	for i, colValues := range rowsColValues {
+		found := false
+		typeIdString := colValues[0].ToString()
+		idString := colValues[1].ToString()
+
+		for subvindexName, subvindexRowsColValues := range subvindexToRowsColValues {
+			idx := subvindexToIndex[subvindexName]
+			if idx >= len(subvindexToRowsColValues[subvindexName]) {
+				continue
+			}
+			subvindexColValues := subvindexRowsColValues[idx]
+			if typeIdString == subvindexColValues[0].ToString() && idString == subvindexColValues[1].ToString() {
+				res := subvindexToResult[subvindexName][idx]
+				out[i] = res
+				subvindexToIndex[subvindexName]++
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return nil, fmt.Errorf("Multisharded.Verify: no result found for input column values %v with ksid %v", colValues, ksids[i])
+		}
+	}
+
+	return out, nil
+
+}
+
+func (m *MultiSharded) separateBySubvindex(rowsColValues [][]sqltypes.Value, ksids [][]byte) (map[string][][]sqltypes.Value, map[string][][]byte, error) {
+	var subvindexToRowsColValues = make(map[string][][]sqltypes.Value)
+	var subvindexToKsids = make(map[string][][]byte)
+	for i, colValues := range rowsColValues {
+		subvindexName, ok := m.typeIdToVindexName[colValues[0].ToString()]
+		if !ok {
+			return nil, nil, fmt.Errorf("MultiSharded.separateBySubvindex: no subvindex found for typeId %v with id %v", colValues[0], colValues[1])
+		}
+
+		// Check if id is valid
+		_, err := evalengine.ToUint64(colValues[1])
+		if err != nil {
+			return nil, nil, err
+		}
+		subvindexToRowsColValues[subvindexName] = append(subvindexToRowsColValues[subvindexName], colValues)
+
+		if len(ksids) > 0 {
+			subvindexToKsids[subvindexName] = append(subvindexToKsids[subvindexName], ksids[i])
+		}
+	}
+	return subvindexToRowsColValues, subvindexToKsids, nil
+}

--- a/go/vt/vtgate/vindexes/multisharded_test.go
+++ b/go/vt/vtgate/vindexes/multisharded_test.go
@@ -35,7 +35,7 @@ func TestMultiShardedCreation(t *testing.T) {
 	}
 
 	params := map[string]string{
-		"owner_type_to_vindex": `{"1":"etsy_hybrid_user", "2":"etsy_hybrid_shop"}`,
+		"type_id_to_vindex": `{"1":"etsy_hybrid_user", "2":"etsy_hybrid_shop"}`,
 	}
 
 	expectedName := "multisharded_test"
@@ -58,7 +58,7 @@ func TestMultiShardedCreation(t *testing.T) {
 
 	if diff != "" {
 		t.Errorf(
-			"Got unexpected value for multisharded.ownerTypeToVindexName. Expected: %v, Got: %v",
+			"Got unexpected value for multisharded.TypeIdToVindexName. Expected: %v, Got: %v",
 			expectedTypeIdToSubvindexName,
 			multisharded.(*MultiSharded).typeIdToSubvindexName)
 	}
@@ -86,7 +86,7 @@ func TestMultiShardedCreationWithNonexistantSubvindex(t *testing.T) {
 	}
 
 	params := map[string]string{
-		"owner_type_to_vindex": `{"1":"etsy_hybrid_user", "2":"etsy_hybrid_shop"}`,
+		"type_id_to_vindex": `{"1":"etsy_hybrid_user", "2":"etsy_hybrid_shop"}`,
 	}
 
 	expectedName := "multisharded_test"
@@ -98,11 +98,11 @@ func TestMultiShardedCreationWithNonexistantSubvindex(t *testing.T) {
 
 func TestMultiShardedMap(t *testing.T) {
 	cases := []struct {
-		name              string
-		ownerTypeToVindex string
-		rowsColValues     [][]sqltypes.Value
-		expected          []key.Destination
-		shouldErr         bool
+		name           string
+		typeIdToVindex string
+		rowsColValues  [][]sqltypes.Value
+		expected       []key.Destination
+		shouldErr      bool
 	}{
 		{
 			"All rows map to same subvindex",
@@ -214,7 +214,7 @@ func TestMultiShardedMap(t *testing.T) {
 			multisharded, err := CreateVindex(
 				"etsy_multisharded_hybrid",
 				"multisharded_test",
-				map[string]string{"owner_type_to_vindex": c.ownerTypeToVindex})
+				map[string]string{"type_id_to_vindex": c.typeIdToVindex})
 
 			if err != nil {
 				t.Fatal(err)
@@ -242,12 +242,12 @@ func TestMultiShardedMap(t *testing.T) {
 
 func TestMultiShardedVerify(t *testing.T) {
 	cases := []struct {
-		name              string
-		ownerTypeToVindex string
-		rowsColValues     [][]sqltypes.Value
-		ksids             [][]byte
-		expected          []bool
-		shouldErr         bool
+		name           string
+		typeIdToVindex string
+		rowsColValues  [][]sqltypes.Value
+		ksids          [][]byte
+		expected       []bool
+		shouldErr      bool
 	}{
 		{
 			"Same subvindex, all ksids map correctly to ids",
@@ -434,7 +434,7 @@ func TestMultiShardedVerify(t *testing.T) {
 			multisharded, err := CreateVindex(
 				"etsy_multisharded_hybrid",
 				"multisharded_test",
-				map[string]string{"owner_type_to_vindex": c.ownerTypeToVindex})
+				map[string]string{"type_id_to_vindex": c.typeIdToVindex})
 
 			if err != nil {
 				t.Fatal(err)
@@ -462,10 +462,10 @@ func TestMultiShardedVerify(t *testing.T) {
 
 func TestMultiShardedCost(t *testing.T) {
 	cases := []struct {
-		name              string
-		costs             []int
-		ownerTypeToVindex string
-		expected          int
+		name           string
+		costs          []int
+		typeIdToVindex string
+		expected       int
 	}{
 		{"No subvindexes", []int{}, `{}`, 0},
 		{"All costs are 0", []int{0, 0, 0}, `{"1":"hybrid1", "2":"hybrid2", "3":"hybrid3"}`, 0},
@@ -488,7 +488,7 @@ func TestMultiShardedCost(t *testing.T) {
 
 			// create multisharded vindex
 			params := map[string]string{
-				"owner_type_to_vindex": c.ownerTypeToVindex,
+				"type_id_to_vindex": c.typeIdToVindex,
 			}
 			multisharded, err := CreateVindex("etsy_multisharded_hybrid", "multisharded_test", params)
 			if err != nil {
@@ -506,10 +506,10 @@ func TestMultiShardedCost(t *testing.T) {
 
 func TestMultiShardedIsUnique(t *testing.T) {
 	cases := []struct {
-		name              string
-		isUniqueResults   []bool
-		ownerTypeToVindex string
-		expected          bool
+		name            string
+		isUniqueResults []bool
+		typeIdToVindex  string
+		expected        bool
 	}{
 		{"No subvindexes", []bool{}, `{}`, true},
 		{"All subvindexes are unique", []bool{true, true, true}, `{"1":"hybrid1", "2":"hybrid2", "3":"hybrid3"}`, true},
@@ -532,7 +532,7 @@ func TestMultiShardedIsUnique(t *testing.T) {
 
 			// create multisharded vindex
 			params := map[string]string{
-				"owner_type_to_vindex": c.ownerTypeToVindex,
+				"type_id_to_vindex": c.typeIdToVindex,
 			}
 			multisharded, err := CreateVindex("etsy_multisharded_hybrid", "multisharded_test", params)
 			if err != nil {
@@ -552,7 +552,7 @@ func TestMultiShardedNeedsVCursor(t *testing.T) {
 	cases := []struct {
 		name                string
 		needsVCursorResults []bool
-		ownerTypeToVindex   string
+		typeIdToVindex      string
 		expected            bool
 	}{
 		{"No subvindexes", []bool{}, `{}`, false},
@@ -576,7 +576,7 @@ func TestMultiShardedNeedsVCursor(t *testing.T) {
 
 			// create multisharded vindex
 			params := map[string]string{
-				"owner_type_to_vindex": c.ownerTypeToVindex,
+				"type_id_to_vindex": c.typeIdToVindex,
 			}
 			multisharded, err := CreateVindex("etsy_multisharded_hybrid", "multisharded_test", params)
 			if err != nil {

--- a/go/vt/vtgate/vindexes/multisharded_test.go
+++ b/go/vt/vtgate/vindexes/multisharded_test.go
@@ -1,0 +1,581 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vindexes
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/key"
+)
+
+// Ensure that MultiSharded properties are correctly defined upon creation
+func TestMultiShardedCreation(t *testing.T) {
+	hybridVindexes = map[string]SingleColumn{
+		"etsy_hybrid_user": &HybridStub{},
+		"etsy_hybrid_shop": &HybridStub{},
+	}
+
+	params := map[string]string{
+		"owner_type_to_vindex": `{"1":"etsy_hybrid_user", "2":"etsy_hybrid_shop"}`,
+	}
+
+	expectedName := "multisharded_test"
+	multisharded, err := CreateVindex("etsy_multisharded", expectedName, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actualName := multisharded.String()
+	if actualName != expectedName {
+		t.Errorf(
+			"Got unexpected value for multisharded.String(). Expected: %v, Got: %v",
+			expectedName,
+			actualName)
+	}
+
+	expectedTypeIdToVindexName := map[string]string{"1": "etsy_hybrid_user", "2": "etsy_hybrid_shop"}
+	diff := cmp.Diff(multisharded.(*MultiSharded).typeIdToVindexName,
+		expectedTypeIdToVindexName)
+
+	if diff != "" {
+		t.Errorf(
+			"Got unexpected value for multisharded.ownerTypeToVindexName. Expected: %v, Got: %v",
+			expectedTypeIdToVindexName,
+			multisharded.(*MultiSharded).typeIdToVindexName)
+	}
+
+	expectedSubvindexMap := map[string]SingleColumn{
+		"etsy_hybrid_user": &HybridStub{},
+		"etsy_hybrid_shop": &HybridStub{},
+	}
+
+	diff = cmp.Diff(multisharded.(*MultiSharded).subvindexMap,
+		expectedSubvindexMap, cmp.AllowUnexported(HybridStub{}))
+
+	if diff != "" {
+		t.Errorf(
+			"Got unexpected value for multisharded.subvindexMap. Expected: %v, Got: %v",
+			expectedSubvindexMap,
+			multisharded.(*MultiSharded).subvindexMap)
+	}
+}
+
+func TestMultiShardedMap(t *testing.T) {
+	cases := []struct {
+		name              string
+		ownerTypeToVindex string
+		rowsColValues     [][]sqltypes.Value
+		expected          []key.Destination
+		shouldErr         bool
+	}{
+		{
+			"All rows map to same subvindex",
+			`{"1":"subvindex_a", "2":"subvindex_b"}`,
+			[][]sqltypes.Value{
+				{sqltypes.NewInt64(1), sqltypes.NewInt64(1)},
+				{sqltypes.NewInt64(1), sqltypes.NewInt64(5)},
+				{sqltypes.NewInt64(1), sqltypes.NewInt64(7)},
+			},
+			[]key.Destination{
+				key.DestinationKeyspaceID([]byte("10")),
+				key.DestinationKeyspaceID([]byte("20")),
+				key.DestinationNone{},
+			},
+			false,
+		},
+		{
+			"Rows map to different subvindexes",
+			`{"1":"subvindex_a", "2":"subvindex_b"}`,
+			[][]sqltypes.Value{
+				{sqltypes.NewInt64(1), sqltypes.NewInt64(1)},
+				{sqltypes.NewInt64(2), sqltypes.NewInt64(60)},
+				{sqltypes.NewInt64(2), sqltypes.NewInt64(70)},
+			},
+			[]key.Destination{
+				key.DestinationKeyspaceID([]byte("10")),
+				key.DestinationKeyspaceID([]byte("200")),
+				key.DestinationNone{},
+			},
+			false,
+		},
+		{
+			"Some rows map to subvindexes",
+			`{"1":"subvindex_a", "2":"subvindex_b"}`,
+			[][]sqltypes.Value{
+				{sqltypes.NewInt64(1), sqltypes.NewInt64(1)},
+				{sqltypes.NewInt64(2), sqltypes.NewInt64(60)},
+				{sqltypes.NewInt64(500), sqltypes.NewInt64(70)},
+			},
+			nil,
+			true,
+		},
+		{
+			"No rows map to subvindexes",
+			`{"1":"subvindex_a", "2":"subvindex_b"}`,
+			[][]sqltypes.Value{
+				{sqltypes.NewInt64(100), sqltypes.NewInt64(1)},
+				{sqltypes.NewInt64(200), sqltypes.NewInt64(60)},
+				{sqltypes.NewInt64(500), sqltypes.NewInt64(70)},
+			},
+			nil,
+			true,
+		},
+	}
+
+	// TODO: Move this into helper?
+	hybridVindexes = make(map[string]SingleColumn)
+	hybridVindexes["subvindex_a"] = &HybridStub{
+		mapFunc: func(ids []sqltypes.Value) ([]key.Destination, error) {
+			res := make([]key.Destination, 0, len(ids))
+			for _, id := range ids {
+				switch id.ToString() {
+				case "1", "2", "3":
+					res = append(res, key.DestinationKeyspaceID([]byte("10")))
+				case "4", "5", "6":
+					res = append(res, key.DestinationKeyspaceID([]byte("20")))
+				default:
+					res = append(res, key.DestinationNone{})
+				}
+			}
+			return res, nil
+		},
+	}
+
+	hybridVindexes["subvindex_b"] = &HybridStub{
+		mapFunc: func(ids []sqltypes.Value) ([]key.Destination, error) {
+			res := make([]key.Destination, 0, len(ids))
+			for _, id := range ids {
+				switch id.ToString() {
+				case "10", "20", "30":
+					res = append(res, key.DestinationKeyspaceID([]byte("100")))
+				case "40", "50", "60":
+					res = append(res, key.DestinationKeyspaceID([]byte("200")))
+				default:
+					res = append(res, key.DestinationNone{})
+				}
+			}
+			return res, nil
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			multisharded, err := CreateVindex(
+				"etsy_multisharded",
+				"multisharded_test",
+				map[string]string{"owner_type_to_vindex": c.ownerTypeToVindex})
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			actual, err := multisharded.(*MultiSharded).Map(context.Background(), nil, c.rowsColValues)
+			if !c.shouldErr {
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				diff := cmp.Diff(actual, c.expected)
+				if diff != "" {
+					t.Errorf("Got unexpected result from multisharded.Map. Expected: %v. Actual: %v.", c.expected, actual)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Expected error from multisharded.Map, got nil")
+				}
+			}
+
+		})
+	}
+}
+
+func TestMultiShardedVerify(t *testing.T) {
+	cases := []struct {
+		name              string
+		ownerTypeToVindex string
+		rowsColValues     [][]sqltypes.Value
+		ksids             [][]byte
+		expected          []bool
+		shouldErr         bool
+	}{
+		{
+			"Same subvindex, all ksids map correctly to ids",
+			`{"1":"subvindex_a", "2":"subvindex_b"}`,
+			[][]sqltypes.Value{
+				{sqltypes.NewInt64(1), sqltypes.NewInt64(1)},
+				{sqltypes.NewInt64(1), sqltypes.NewInt64(2)},
+				{sqltypes.NewInt64(1), sqltypes.NewInt64(5)},
+			},
+			[][]byte{
+				[]byte("20"),
+				[]byte("10"),
+				[]byte("200"),
+			},
+			[]bool{true, true, true},
+			false,
+		},
+		{
+			"Same subvindex, some incorrect ksids",
+			`{"1":"subvindex_a", "2":"subvindex_b"}`,
+			[][]sqltypes.Value{
+				{sqltypes.NewInt64(1), sqltypes.NewInt64(1)},
+				{sqltypes.NewInt64(1), sqltypes.NewInt64(2)},
+				{sqltypes.NewInt64(1), sqltypes.NewInt64(5)},
+			},
+			[][]byte{
+				[]byte("20"),
+				[]byte("1000"),
+				[]byte("10"),
+			},
+			[]bool{true, false, false},
+			false,
+		},
+		{
+			"Different subvindexes, all ksids map correctly to ids",
+			`{"1":"subvindex_a", "2":"subvindex_b"}`,
+			[][]sqltypes.Value{
+				{sqltypes.NewInt64(1), sqltypes.NewInt64(1)},
+				{sqltypes.NewInt64(1), sqltypes.NewInt64(2)},
+				{sqltypes.NewInt64(2), sqltypes.NewInt64(30)},
+			},
+			[][]byte{
+				[]byte("20"),
+				[]byte("10"),
+				[]byte("30"),
+			},
+			[]bool{true, true, true},
+			false,
+		},
+		{
+			"Different subvindexes, some incorrect ksids",
+			`{"1":"subvindex_a", "2":"subvindex_b"}`,
+			[][]sqltypes.Value{
+				{sqltypes.NewInt64(1), sqltypes.NewInt64(1)},
+				{sqltypes.NewInt64(1), sqltypes.NewInt64(2)},
+				{sqltypes.NewInt64(2), sqltypes.NewInt64(30)},
+			},
+			[][]byte{
+				[]byte("20"),
+				[]byte("1000"),
+				[]byte("3000"),
+			},
+			[]bool{true, false, false},
+			false,
+		},
+		{
+			"Different subvindexes, no correct ksids",
+			`{"1":"subvindex_a", "2":"subvindex_b"}`,
+			[][]sqltypes.Value{
+				{sqltypes.NewInt64(1), sqltypes.NewInt64(1)},
+				{sqltypes.NewInt64(1), sqltypes.NewInt64(2)},
+				{sqltypes.NewInt64(2), sqltypes.NewInt64(30)},
+				{sqltypes.NewInt64(2), sqltypes.NewInt64(10000)},
+			},
+			[][]byte{
+				[]byte("2000"),
+				[]byte("1000"),
+				[]byte("3000"),
+				[]byte("4000"),
+			},
+			[]bool{false, false, false, false},
+			false,
+		},
+		{
+			"Some rows map to subvindexes",
+			`{"1":"subvindex_a", "2":"subvindex_b"}`,
+			[][]sqltypes.Value{
+				{sqltypes.NewInt64(1), sqltypes.NewInt64(1)},
+				{sqltypes.NewInt64(1), sqltypes.NewInt64(2)},
+				{sqltypes.NewInt64(200), sqltypes.NewInt64(5)},
+			},
+			[][]byte{
+				[]byte("20"),
+				[]byte("10"),
+				[]byte("200"),
+			},
+			nil,
+			true,
+		},
+		{
+			"No rows map to subvindexes",
+			`{"1":"subvindex_a", "2":"subvindex_b"}`,
+			[][]sqltypes.Value{
+				{sqltypes.NewInt64(100), sqltypes.NewInt64(1)},
+				{sqltypes.NewInt64(200), sqltypes.NewInt64(2)},
+				{sqltypes.NewInt64(300), sqltypes.NewInt64(5)},
+			},
+			[][]byte{
+				[]byte("20"),
+				[]byte("10"),
+				[]byte("200"),
+			},
+			nil,
+			true,
+		},
+	}
+
+	// TODO: Move this into helper?
+	hybridVindexes = make(map[string]SingleColumn)
+	hybridVindexes["subvindex_a"] = &HybridStub{
+		verify: func(ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
+			res := make([]bool, 0, len(ids))
+			for i, id := range ids {
+				switch id.ToString() {
+				case "1", "2", "3":
+					if bytes.Equal(ksids[i], []byte("10")) || bytes.Equal(ksids[i], []byte("20")) {
+						res = append(res, true)
+					} else {
+						res = append(res, false)
+					}
+				case "4", "5", "6":
+					if bytes.Equal(ksids[i], []byte("100")) || bytes.Equal(ksids[i], []byte("200")) {
+						res = append(res, true)
+					} else {
+						res = append(res, false)
+					}
+				default:
+					res = append(res, false)
+				}
+			}
+			return res, nil
+		},
+	}
+
+	hybridVindexes["subvindex_b"] = &HybridStub{
+		verify: func(ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
+			res := make([]bool, 0, len(ids))
+			for i, id := range ids {
+				switch id.ToString() {
+				case "10", "20", "30":
+					if bytes.Equal(ksids[i], []byte("30")) || bytes.Equal(ksids[i], []byte("40")) {
+						res = append(res, true)
+					} else {
+						res = append(res, false)
+					}
+				case "40", "50", "60":
+					if bytes.Equal(ksids[i], []byte("300")) || bytes.Equal(ksids[i], []byte("400")) {
+						res = append(res, true)
+					} else {
+						res = append(res, false)
+					}
+				default:
+					res = append(res, false)
+				}
+			}
+			return res, nil
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			multisharded, err := CreateVindex(
+				"etsy_multisharded",
+				"multisharded_test",
+				map[string]string{"owner_type_to_vindex": c.ownerTypeToVindex})
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			actual, err := multisharded.(*MultiSharded).Verify(context.Background(), nil, c.rowsColValues, c.ksids)
+			if !c.shouldErr {
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				diff := cmp.Diff(actual, c.expected)
+				if diff != "" {
+					t.Errorf("Got unexpected result from multisharded.Verify. Expected: %v. Actual: %v.", c.expected, actual)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Expected error from multisharded.Verify, got nil")
+				}
+			}
+
+		})
+	}
+}
+
+func TestMultiShardedCost(t *testing.T) {
+	cases := []struct {
+		name              string
+		costs             []int
+		ownerTypeToVindex string
+		expected          int
+	}{
+		{"No subvindexes", []int{}, `{}`, 0},
+		{"All costs are 0", []int{0, 0, 0}, `{"1":"hybrid1", "2":"hybrid2", "3":"hybrid3"}`, 0},
+		{"All costs are 1", []int{1, 1, 1}, `{"1":"hybrid1", "2":"hybrid2", "3":"hybrid3"}`, 1},
+		{"Greatest cost is 2", []int{0, 2, 0}, `{"1":"hybrid1", "2":"hybrid2", "3":"hybrid3"}`, 2},
+	}
+
+	for _, c := range cases {
+		hybridVindexes = make(map[string]SingleColumn)
+		t.Run(c.name, func(t *testing.T) {
+			// Populate hybridVindexes with stub subvindexes
+			for i, cost := range c.costs {
+				costCopy := cost
+				hybridVindexes[fmt.Sprintf("hybrid%d", i+1)] = &HybridStub{
+					cost: func() int {
+						return costCopy
+					},
+				}
+			}
+
+			// create multisharded vindex
+			params := map[string]string{
+				"owner_type_to_vindex": c.ownerTypeToVindex,
+			}
+			multisharded, err := CreateVindex("etsy_multisharded", "multisharded_test", params)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			actual := multisharded.Cost()
+			if actual != c.expected {
+				t.Errorf("Expected cost %d, got %d", c.expected, actual)
+			}
+
+		})
+	}
+}
+
+func TestMultiShardedIsUnique(t *testing.T) {
+	cases := []struct {
+		name              string
+		isUniqueResults   []bool
+		ownerTypeToVindex string
+		expected          bool
+	}{
+		{"No subvindexes", []bool{}, `{}`, true},
+		{"All subvindexes are unique", []bool{true, true, true}, `{"1":"hybrid1", "2":"hybrid2", "3":"hybrid3"}`, true},
+		{"All subvindexes are not unique", []bool{false, false, false}, `{"1":"hybrid1", "2":"hybrid2", "3":"hybrid3"}`, false},
+		{"Some subvindexes are unique", []bool{true, false, true}, `{"1":"hybrid1", "2":"hybrid2", "3":"hybrid3"}`, false},
+	}
+
+	for _, c := range cases {
+		hybridVindexes = make(map[string]SingleColumn)
+		t.Run(c.name, func(t *testing.T) {
+			// Populate hybridVindexes with stub subvindexes
+			for i, isUnique := range c.isUniqueResults {
+				isUniqueCopy := isUnique
+				hybridVindexes[fmt.Sprintf("hybrid%d", i+1)] = &HybridStub{
+					isUnique: func() bool {
+						return isUniqueCopy
+					},
+				}
+			}
+
+			// create multisharded vindex
+			params := map[string]string{
+				"owner_type_to_vindex": c.ownerTypeToVindex,
+			}
+			multisharded, err := CreateVindex("etsy_multisharded", "multisharded_test", params)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			actual := multisharded.IsUnique()
+			if actual != c.expected {
+				t.Errorf("Expected IsUnique result %v, got %v", c.expected, actual)
+			}
+
+		})
+	}
+}
+
+func TestMultiShardedNeedsVCursor(t *testing.T) {
+	cases := []struct {
+		name                string
+		needsVCursorResults []bool
+		ownerTypeToVindex   string
+		expected            bool
+	}{
+		{"No subvindexes", []bool{}, `{}`, false},
+		{"No subvindexes need Vcursor", []bool{false, false, false}, `{"1":"hybrid1", "2":"hybrid2", "3":"hybrid3"}`, false},
+		{"All subvindexes need Vcursor", []bool{true, true, true}, `{"1":"hybrid1", "2":"hybrid2", "3":"hybrid3"}`, true},
+		{"1 subvindex needs Vcursor", []bool{true, false, false}, `{"1":"hybrid1", "2":"hybrid2", "3":"hybrid3"}`, true},
+	}
+
+	for _, c := range cases {
+		hybridVindexes = make(map[string]SingleColumn)
+		t.Run(c.name, func(t *testing.T) {
+			// Populate hybridVindexes with stub subvindexes
+			for i, needsVcursor := range c.needsVCursorResults {
+				needsVCursorCopy := needsVcursor
+				hybridVindexes[fmt.Sprintf("hybrid%d", i+1)] = &HybridStub{
+					needsVCursor: func() bool {
+						return needsVCursorCopy
+					},
+				}
+			}
+
+			// create multisharded vindex
+			params := map[string]string{
+				"owner_type_to_vindex": c.ownerTypeToVindex,
+			}
+			multisharded, err := CreateVindex("etsy_multisharded", "multisharded_test", params)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			actual := multisharded.NeedsVCursor()
+			if actual != c.expected {
+				t.Errorf("Expected NeedsVCursor result %v, got %v", c.expected, actual)
+			}
+
+		})
+	}
+}
+
+// Set up for subvindex stubs
+type HybridStub struct {
+	cost         func() int
+	isUnique     func() bool
+	needsVCursor func() bool
+	stringFunc   func() string
+	mapFunc      func(ids []sqltypes.Value) ([]key.Destination, error)
+	verify       func(ids []sqltypes.Value, ksids [][]byte) ([]bool, error)
+}
+
+func (h *HybridStub) Cost() int {
+	return h.cost()
+}
+
+func (h *HybridStub) IsUnique() bool {
+	return h.isUnique()
+}
+
+func (h *HybridStub) NeedsVCursor() bool {
+	return h.needsVCursor()
+}
+
+func (h *HybridStub) String() string {
+	return h.stringFunc()
+}
+
+func (h *HybridStub) Map(ctx context.Context, vcursor VCursor, ids []sqltypes.Value) ([]key.Destination, error) {
+	return h.mapFunc(ids)
+}
+
+func (h *HybridStub) Verify(ctx context.Context, vcursor VCursor, ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
+	return h.verify(ids, ksids)
+}


### PR DESCRIPTION
## This PR
Creates new multicolumn vindex requried for Etsy's Vitess-managed sharding strategy. The new MultiSharded vindex accepts two columns representing a type_id and an id, and provides a way to specify a mapping between a type id and a vindex type. It then chooses the vindex that is used based on the type_id column.

This patch also adds logic that stores (within a new `hybridVindexes` variable) a mapping of Hybrid vindex instance names to Hybrid vindex instances, which are used by the MultiSharded vindex.

## Multisharded Vindex usage

In the vschema.json, the multisharded vindex should be defined as the example below.
The `"owner_type_to_vindex"` param should be a json-encoded mapping of a string integer to the name of a previously-defined hybrid vindex.

Note that vindexes defined in ` "owner_type_to_vindex"` _must_ be defined above the definition for any multisharded vindexes, because the multisharded vindex assumes the hybrid vindexes it references have been previously loaded on the vtgates.

```json
{
    "sharded": true,
    "vindexes": {
      // esty_shard_hybrid user and etsy_shard_hybrid_shop must be defined here, above etsy_shard_multisharded
      "etsy_shard_multisharded": {
        "type": "etsy_multisharded",
        "params": {
          "owner_type_to_vindex" : "{\"2\":\"etsy_shard_hybrid_user\",\"3\":\"etsy_shard_hybrid_shop\"}"
        }
      }
    }, 
}
```

A multisharded table would be defined in the vschema.json as such:

```json
    "tables": {
      "connection_log": 
          { "column_vindexes": [ { "name": "etsy_shard_multisharded", "columns": ["from_type_id", "from_id"] } ] }
    }
```

## Testing
### Functional
- Added unit tests for new logic
- Tested issuing queries on multisharded table on vbox/parallels

### Performance
Perf testing on v157-vtgate-blue-0-x6k2.c.etsy-vitess-sandbox.internal, making mysql calls from my VM. 

For testing, I followed the steps outlined in https://github.com/etsy/vitess-scripts/pull/16, except that I used a slightly different version of the `compare_mysql_perf.php` script to allow for multi-column pkids: https://github.etsycorp.com/gist/swu/7623fa4d3afc726c55ccb23aa52e98ed

I tested querying a multisharded table with the new multisharded vindex (with ~70% of shop_ids and 90% of user_ids below the hybrid thresholds). I compared this against a "baseline" of using shard-targeting against a build of main (what's currently running on the prod vtgates) without any vindexes.

The results were not very different, though strangely the multisharded vindex test results were faster than the "baseline" results: https://docs.google.com/spreadsheets/d/11O8m_iBhDiq_4GGEujCTY0ic-CHu-_ykz4BzHJlrYrg/edit#gid=1352270885

## Additional context
See w.sung's doc for discussion of the multisharded vindex approach and the use case it solves for: https://docs.google.com/document/d/1VOi6xEgkeC69soahgdEp7zuC8E64xQSVm_NGTN0MnCk

