### PR TITLE
[DAP-5348] Pass in keyspace-level vschema vindex configuration info to newVindexFunc() so that vindexes can access config info for other vindexes defined in the same vschema.

### DIFF
--- a/go/vt/vtgate/engine/delete_test.go
+++ b/go/vt/vtgate/engine/delete_test.go
@@ -65,7 +65,7 @@ func TestDeleteUnsharded(t *testing.T) {
 }
 
 func TestDeleteEqual(t *testing.T) {
-	vindex, _ := vindexes.NewHash("", nil)
+	vindex, _ := vindexes.NewHash("", nil, nil)
 	del := &Delete{
 		DML: &DML{
 			RoutingParameters: &RoutingParameters{
@@ -97,7 +97,7 @@ func TestDeleteEqual(t *testing.T) {
 }
 
 func TestDeleteEqualMultiCol(t *testing.T) {
-	vindex, _ := vindexes.NewRegionExperimental("", map[string]string{"region_bytes": "1"})
+	vindex, _ := vindexes.NewRegionExperimental("", map[string]string{"region_bytes": "1"}, nil)
 	del := &Delete{
 		DML: &DML{
 			RoutingParameters: &RoutingParameters{
@@ -133,7 +133,7 @@ func TestDeleteEqualNoRoute(t *testing.T) {
 		"table": "lkp",
 		"from":  "from",
 		"to":    "toc",
-	})
+	}, nil)
 	del := &Delete{
 		DML: &DML{
 			RoutingParameters: &RoutingParameters{
@@ -166,7 +166,7 @@ func TestDeleteEqualNoScatter(t *testing.T) {
 		"from":       "from",
 		"to":         "toc",
 		"write_only": "true",
-	})
+	}, nil)
 	del := &Delete{
 		DML: &DML{
 			RoutingParameters: &RoutingParameters{
@@ -556,7 +556,7 @@ func TestDeleteInChangedVindexMultiCol(t *testing.T) {
 }
 
 func TestDeleteEqualSubshard(t *testing.T) {
-	vindex, _ := vindexes.NewRegionExperimental("", map[string]string{"region_bytes": "1"})
+	vindex, _ := vindexes.NewRegionExperimental("", map[string]string{"region_bytes": "1"}, nil)
 	del := &Delete{
 		DML: &DML{
 			RoutingParameters: &RoutingParameters{

--- a/go/vt/vtgate/engine/plan_description_test.go
+++ b/go/vt/vtgate/engine/plan_description_test.go
@@ -50,7 +50,7 @@ func TestCreateRoutePlanDescription(t *testing.T) {
 }
 
 func createRoute() *Route {
-	hash, _ := vindexes.NewHash("vindex name", nil)
+	hash, _ := vindexes.NewHash("vindex name", nil, nil)
 	return &Route{
 		RoutingParameters: &RoutingParameters{
 			Opcode:            Scatter,

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -236,7 +236,7 @@ func TestSelectScatter(t *testing.T) {
 }
 
 func TestSelectEqualUnique(t *testing.T) {
-	vindex, _ := vindexes.NewHash("", nil)
+	vindex, _ := vindexes.NewHash("", nil, nil)
 	sel := NewRoute(
 		EqualUnique,
 		&vindexes.Keyspace{
@@ -274,7 +274,7 @@ func TestSelectEqualUnique(t *testing.T) {
 }
 
 func TestSelectNone(t *testing.T) {
-	vindex, _ := vindexes.NewHash("", nil)
+	vindex, _ := vindexes.NewHash("", nil, nil)
 	sel := NewRoute(
 		None,
 		&vindexes.Keyspace{
@@ -330,7 +330,7 @@ func TestSelectEqualUniqueScatter(t *testing.T) {
 		"from":       "from",
 		"to":         "toc",
 		"write_only": "true",
-	})
+	}, nil)
 	sel := NewRoute(
 		EqualUnique,
 		&vindexes.Keyspace{
@@ -372,7 +372,7 @@ func TestSelectEqual(t *testing.T) {
 		"table": "lkp",
 		"from":  "from",
 		"to":    "toc",
-	})
+	}, nil)
 	sel := NewRoute(
 		Equal,
 		&vindexes.Keyspace{
@@ -425,7 +425,7 @@ func TestSelectEqualNoRoute(t *testing.T) {
 		"table": "lkp",
 		"from":  "from",
 		"to":    "toc",
-	})
+	}, nil)
 	sel := NewRoute(
 		Equal,
 		&vindexes.Keyspace{
@@ -485,7 +485,7 @@ func TestSelectEqualNoRoute(t *testing.T) {
 }
 
 func TestINUnique(t *testing.T) {
-	vindex, _ := vindexes.NewHash("", nil)
+	vindex, _ := vindexes.NewHash("", nil, nil)
 	sel := NewRoute(
 		IN,
 		&vindexes.Keyspace{
@@ -534,7 +534,7 @@ func TestINNonUnique(t *testing.T) {
 		"table": "lkp",
 		"from":  "from",
 		"to":    "toc",
-	})
+	}, nil)
 	sel := NewRoute(
 		IN,
 		&vindexes.Keyspace{
@@ -597,7 +597,7 @@ func TestINNonUnique(t *testing.T) {
 }
 
 func TestMultiEqual(t *testing.T) {
-	vindex, _ := vindexes.NewHash("", nil)
+	vindex, _ := vindexes.NewHash("", nil, nil)
 	sel := NewRoute(
 		MultiEqual,
 		&vindexes.Keyspace{
@@ -640,7 +640,7 @@ func TestMultiEqual(t *testing.T) {
 }
 
 func TestSelectLike(t *testing.T) {
-	subshard, _ := vindexes.NewCFC("cfc", map[string]string{"hash": "md5", "offsets": "[1,2]"})
+	subshard, _ := vindexes.NewCFC("cfc", map[string]string{"hash": "md5", "offsets": "[1,2]"}, nil)
 	vindex := subshard.(*vindexes.CFC).PrefixVindex()
 	vc := &loggingVCursor{
 		// we have shards '-0c80', '0c80-0d', '0d-40', '40-80', '80-'
@@ -820,7 +820,7 @@ func TestRouteGetFields(t *testing.T) {
 		"table": "lkp",
 		"from":  "from",
 		"to":    "toc",
-	})
+	}, nil)
 	sel := NewRoute(
 		Equal,
 		&vindexes.Keyspace{
@@ -1452,7 +1452,7 @@ func TestExecFail(t *testing.T) {
 }
 
 func TestSelectEqualUniqueMultiColumnVindex(t *testing.T) {
-	vindex, _ := vindexes.NewRegionExperimental("", map[string]string{"region_bytes": "1"})
+	vindex, _ := vindexes.NewRegionExperimental("", map[string]string{"region_bytes": "1"}, nil)
 	sel := NewRoute(
 		EqualUnique,
 		&vindexes.Keyspace{
@@ -1491,7 +1491,7 @@ func TestSelectEqualUniqueMultiColumnVindex(t *testing.T) {
 }
 
 func TestSelectEqualMultiColumnVindex(t *testing.T) {
-	vindex, _ := vindexes.NewRegionExperimental("", map[string]string{"region_bytes": "1"})
+	vindex, _ := vindexes.NewRegionExperimental("", map[string]string{"region_bytes": "1"}, nil)
 	vc := &loggingVCursor{
 		shards:       []string{"-20", "20-"},
 		shardForKsid: []string{"-20", "20-"},
@@ -1528,7 +1528,7 @@ func TestSelectEqualMultiColumnVindex(t *testing.T) {
 }
 
 func TestINMultiColumnVindex(t *testing.T) {
-	vindex, _ := vindexes.NewRegionExperimental("", map[string]string{"region_bytes": "1"})
+	vindex, _ := vindexes.NewRegionExperimental("", map[string]string{"region_bytes": "1"}, nil)
 	sel := NewRoute(
 		IN,
 		&vindexes.Keyspace{
@@ -1574,7 +1574,7 @@ func TestINMultiColumnVindex(t *testing.T) {
 }
 
 func TestINMixedMultiColumnComparision(t *testing.T) {
-	vindex, _ := vindexes.NewRegionExperimental("", map[string]string{"region_bytes": "1"})
+	vindex, _ := vindexes.NewRegionExperimental("", map[string]string{"region_bytes": "1"}, nil)
 	sel := NewRoute(
 		IN,
 		&vindexes.Keyspace{
@@ -1617,7 +1617,7 @@ func TestINMixedMultiColumnComparision(t *testing.T) {
 }
 
 func TestMultiEqualMultiCol(t *testing.T) {
-	vindex, _ := vindexes.NewRegionExperimental("", map[string]string{"region_bytes": "1"})
+	vindex, _ := vindexes.NewRegionExperimental("", map[string]string{"region_bytes": "1"}, nil)
 	sel := NewRoute(
 		MultiEqual,
 		&vindexes.Keyspace{Name: "ks", Sharded: true},

--- a/go/vt/vtgate/engine/update_test.go
+++ b/go/vt/vtgate/engine/update_test.go
@@ -69,7 +69,7 @@ func TestUpdateUnsharded(t *testing.T) {
 }
 
 func TestUpdateEqual(t *testing.T) {
-	vindex, _ := vindexes.NewHash("", nil)
+	vindex, _ := vindexes.NewHash("", nil, nil)
 	upd := &Update{
 		DML: &DML{
 			RoutingParameters: &RoutingParameters{
@@ -100,7 +100,7 @@ func TestUpdateEqual(t *testing.T) {
 }
 
 func TestUpdateEqualMultiCol(t *testing.T) {
-	vindex, _ := vindexes.NewRegionExperimental("", map[string]string{"region_bytes": "1"})
+	vindex, _ := vindexes.NewRegionExperimental("", map[string]string{"region_bytes": "1"}, nil)
 	upd := &Update{
 		DML: &DML{
 			RoutingParameters: &RoutingParameters{
@@ -126,7 +126,7 @@ func TestUpdateEqualMultiCol(t *testing.T) {
 }
 
 func TestUpdateScatter(t *testing.T) {
-	vindex, _ := vindexes.NewHash("", nil)
+	vindex, _ := vindexes.NewHash("", nil, nil)
 	upd := &Update{
 		DML: &DML{
 			RoutingParameters: &RoutingParameters{
@@ -183,7 +183,7 @@ func TestUpdateEqualNoRoute(t *testing.T) {
 		"table": "lkp",
 		"from":  "from",
 		"to":    "toc",
-	})
+	}, nil)
 	upd := &Update{
 		DML: &DML{
 			RoutingParameters: &RoutingParameters{
@@ -216,7 +216,7 @@ func TestUpdateEqualNoScatter(t *testing.T) {
 		"from":       "from",
 		"to":         "toc",
 		"write_only": "true",
-	})
+	}, nil)
 	upd := &Update{
 		DML: &DML{
 			RoutingParameters: &RoutingParameters{
@@ -891,7 +891,7 @@ func TestUpdateInChangedVindexMultiCol(t *testing.T) {
 }
 
 func TestUpdateEqualSubshard(t *testing.T) {
-	vindex, _ := vindexes.NewRegionExperimental("", map[string]string{"region_bytes": "1"})
+	vindex, _ := vindexes.NewRegionExperimental("", map[string]string{"region_bytes": "1"}, nil)
 	upd := &Update{
 		DML: &DML{
 			RoutingParameters: &RoutingParameters{

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -26,6 +26,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vtgate/logstats"
 
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 
 	"github.com/stretchr/testify/require"
@@ -387,7 +388,7 @@ func (*keyRangeLookuper) Map(ctx context.Context, vcursor vindexes.VCursor, ids 
 	}, nil
 }
 
-func newKeyRangeLookuper(name string, params map[string]string) (vindexes.Vindex, error) {
+func newKeyRangeLookuper(name string, params map[string]string, _ map[string]*vschemapb.Vindex) (vindexes.Vindex, error) {
 	return &keyRangeLookuper{}, nil
 }
 
@@ -412,7 +413,7 @@ func (*keyRangeLookuperUnique) Map(ctx context.Context, vcursor vindexes.VCursor
 	}, nil
 }
 
-func newKeyRangeLookuperUnique(name string, params map[string]string) (vindexes.Vindex, error) {
+func newKeyRangeLookuperUnique(name string, params map[string]string, _ map[string]*vschemapb.Vindex) (vindexes.Vindex, error) {
 	return &keyRangeLookuperUnique{}, nil
 }
 

--- a/go/vt/vtgate/planbuilder/abstract/operator_test.go
+++ b/go/vt/vtgate/planbuilder/abstract/operator_test.go
@@ -86,7 +86,7 @@ func TestOperator(t *testing.T) {
 	require.NoError(t, err)
 	r := bufio.NewReader(fd)
 
-	hash, _ := vindexes.NewHash("user_index", map[string]string{})
+	hash, _ := vindexes.NewHash("user_index", map[string]string{}, nil)
 	si := &semantics.FakeSI{VindexTables: map[string]vindexes.Vindex{"user_index": hash}}
 	lcr := &lineCountingReader{r: r}
 	for {

--- a/go/vt/vtgate/planbuilder/from.go
+++ b/go/vt/vtgate/planbuilder/from.go
@@ -278,7 +278,7 @@ func (pb *primitiveBuilder) buildTablePrimitive(tableExpr *sqlparser.AliasedTabl
 		// Use the Binary vindex, which is the identity function
 		// for keyspace id.
 		eroute = engine.NewSimpleRoute(engine.EqualUnique, vschemaTable.Keyspace)
-		vindex, _ = vindexes.NewBinary("binary", nil)
+		vindex, _ = vindexes.NewBinary("binary", nil, nil)
 		eroute.Vindex = vindex
 		lit := evalengine.NewLiteralString(vschemaTable.Pinned, collations.TypedCollation{})
 		eroute.Values = []evalengine.Expr{lit}

--- a/go/vt/vtgate/planbuilder/physical/route_planning.go
+++ b/go/vt/vtgate/planbuilder/physical/route_planning.go
@@ -424,7 +424,7 @@ func createRoute(ctx *plancontext.PlanningContext, table *abstract.QueryTable, s
 		// Use the Binary vindex, which is the identity function
 		// for keyspace id.
 		plan.RouteOpCode = engine.EqualUnique
-		vindex, _ := vindexes.NewBinary("binary", nil)
+		vindex, _ := vindexes.NewBinary("binary", nil, nil)
 		plan.Selected = &VindexOption{
 			Ready:       true,
 			Values:      []evalengine.Expr{evalengine.NewLiteralString(vschemaTable.Pinned, collations.TypedCollation{})},

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -69,7 +69,7 @@ func (*hashIndex) Map(ctx context.Context, vcursor vindexes.VCursor, ids []sqlty
 	return nil, nil
 }
 
-func newHashIndex(name string, _ map[string]string) (vindexes.Vindex, error) {
+func newHashIndex(name string, _ map[string]string, _ map[string]*vschemapb.Vindex) (vindexes.Vindex, error) {
 	return &hashIndex{name: name}, nil
 }
 
@@ -96,7 +96,7 @@ func (*lookupIndex) Update(context.Context, vindexes.VCursor, []sqltypes.Value, 
 	return nil
 }
 
-func newLookupIndex(name string, _ map[string]string) (vindexes.Vindex, error) {
+func newLookupIndex(name string, _ map[string]string, _ map[string]*vschemapb.Vindex) (vindexes.Vindex, error) {
 	return &lookupIndex{name: name}, nil
 }
 
@@ -133,7 +133,7 @@ func (*nameLkpIndex) MapResult([]sqltypes.Value, []*sqltypes.Result) ([]key.Dest
 	return nil, nil
 }
 
-func newNameLkpIndex(name string, _ map[string]string) (vindexes.Vindex, error) {
+func newNameLkpIndex(name string, _ map[string]string, _ map[string]*vschemapb.Vindex) (vindexes.Vindex, error) {
 	return &nameLkpIndex{name: name}, nil
 }
 
@@ -164,7 +164,7 @@ func (*costlyIndex) Update(context.Context, vindexes.VCursor, []sqltypes.Value, 
 	return nil
 }
 
-func newCostlyIndex(name string, _ map[string]string) (vindexes.Vindex, error) {
+func newCostlyIndex(name string, _ map[string]string, _ map[string]*vschemapb.Vindex) (vindexes.Vindex, error) {
 	return &costlyIndex{name: name}, nil
 }
 
@@ -176,7 +176,7 @@ type multiColIndex struct {
 	name string
 }
 
-func newMultiColIndex(name string, _ map[string]string) (vindexes.Vindex, error) {
+func newMultiColIndex(name string, _ map[string]string, _ map[string]*vschemapb.Vindex) (vindexes.Vindex, error) {
 	return &multiColIndex{name: name}, nil
 }
 

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -1144,7 +1144,7 @@ func TestScopingWVindexTables(t *testing.T) {
 		t.Run(query.query, func(t *testing.T) {
 			parse, err := sqlparser.Parse(query.query)
 			require.NoError(t, err)
-			hash, _ := vindexes.NewHash("user_index", nil)
+			hash, _ := vindexes.NewHash("user_index", nil, nil)
 			st, err := Analyze(parse.(sqlparser.SelectStatement), "user", &FakeSI{
 				Tables: map[string]*vindexes.Table{
 					"t": {Name: sqlparser.NewIdentifierCS("t")},

--- a/go/vt/vtgate/vindexes/binary.go
+++ b/go/vt/vtgate/vindexes/binary.go
@@ -23,6 +23,7 @@ import (
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 )
 
 var (
@@ -37,7 +38,7 @@ type Binary struct {
 }
 
 // NewBinary creates a new Binary.
-func NewBinary(name string, _ map[string]string) (Vindex, error) {
+func NewBinary(name string, _ map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	return &Binary{name: name}, nil
 }
 

--- a/go/vt/vtgate/vindexes/binary_test.go
+++ b/go/vt/vtgate/vindexes/binary_test.go
@@ -34,7 +34,7 @@ import (
 var binOnlyVindex SingleColumn
 
 func init() {
-	vindex, _ := CreateVindex("binary", "binary_varchar", nil)
+	vindex, _ := CreateVindex("binary", "binary_varchar", nil, nil)
 	binOnlyVindex = vindex.(SingleColumn)
 }
 

--- a/go/vt/vtgate/vindexes/binarymd5.go
+++ b/go/vt/vtgate/vindexes/binarymd5.go
@@ -23,6 +23,7 @@ import (
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 )
 
 var (
@@ -36,7 +37,7 @@ type BinaryMD5 struct {
 }
 
 // NewBinaryMD5 creates a new BinaryMD5.
-func NewBinaryMD5(name string, _ map[string]string) (Vindex, error) {
+func NewBinaryMD5(name string, _ map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	return &BinaryMD5{name: name}, nil
 }
 

--- a/go/vt/vtgate/vindexes/binarymd5_test.go
+++ b/go/vt/vtgate/vindexes/binarymd5_test.go
@@ -33,7 +33,7 @@ import (
 var binVindex SingleColumn
 
 func init() {
-	vindex, _ := CreateVindex("binary_md5", "binary_md5_varchar", nil)
+	vindex, _ := CreateVindex("binary_md5", "binary_md5_varchar", nil, nil)
 	binVindex = vindex.(SingleColumn)
 }
 

--- a/go/vt/vtgate/vindexes/cfc.go
+++ b/go/vt/vtgate/vindexes/cfc.go
@@ -24,6 +24,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 )
@@ -94,7 +95,7 @@ type CFC struct {
 }
 
 // NewCFC creates a new CFC vindex
-func NewCFC(name string, params map[string]string) (Vindex, error) {
+func NewCFC(name string, params map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	// CFC is used in all compare expressions other than 'LIKE'.
 	ss := &CFC{
 		name: name,

--- a/go/vt/vtgate/vindexes/cfc_test.go
+++ b/go/vt/vtgate/vindexes/cfc_test.go
@@ -103,7 +103,7 @@ func TestCFCBuildCFC(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.testName, func(t *testing.T) {
-			cfc, err := NewCFC("cfc", tc.params)
+			cfc, err := NewCFC("cfc", tc.params, nil)
 			assertEqualVtError(t, tc.err, err)
 			if cfc != nil {
 				assert.EqualValues(t, tc.offsets, cfc.(*CFC).offsets)
@@ -117,7 +117,7 @@ func TestCFCBuildCFC(t *testing.T) {
 }
 
 func makeCFC(t *testing.T, params map[string]string) *CFC {
-	vind, err := NewCFC("cfc", params)
+	vind, err := NewCFC("cfc", params, nil)
 	require.NoError(t, err)
 	cfc, ok := vind.(*CFC)
 	require.True(t, ok)

--- a/go/vt/vtgate/vindexes/consistent_lookup.go
+++ b/go/vt/vtgate/vindexes/consistent_lookup.go
@@ -30,6 +30,7 @@ import (
 	"vitess.io/vitess/go/vt/key"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	"vitess.io/vitess/go/vt/proto/vtgate"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -63,7 +64,7 @@ type ConsistentLookup struct {
 //	table: name of the backing table. It can be qualified by the keyspace.
 //	from: list of columns in the table that have the 'from' values of the lookup vindex.
 //	to: The 'to' column name of the table.
-func NewConsistentLookup(name string, m map[string]string) (Vindex, error) {
+func NewConsistentLookup(name string, m map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	clc, err := newCLCommon(name, m)
 	if err != nil {
 		return nil, err
@@ -163,7 +164,7 @@ type ConsistentLookupUnique struct {
 //	table: name of the backing table. It can be qualified by the keyspace.
 //	from: list of columns in the table that have the 'from' values of the lookup vindex.
 //	to: The 'to' column name of the table.
-func NewConsistentLookupUnique(name string, m map[string]string) (Vindex, error) {
+func NewConsistentLookupUnique(name string, m map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	clc, err := newCLCommon(name, m)
 	if err != nil {
 		return nil, err

--- a/go/vt/vtgate/vindexes/consistent_lookup_test.go
+++ b/go/vt/vtgate/vindexes/consistent_lookup_test.go
@@ -481,7 +481,7 @@ func createConsistentLookup(t *testing.T, name string, writeOnly bool) SingleCol
 		"from":       "fromc1,fromc2",
 		"to":         "toc",
 		"write_only": write,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/vtgate/vindexes/fuzz.go
+++ b/go/vt/vtgate/vindexes/fuzz.go
@@ -120,7 +120,7 @@ func FuzzVindex(data []byte) int {
 	params["region_map"] = createdFile
 
 	// Create the vindex
-	l, err := CreateVindex(targetVindex, targetVindex, params)
+	l, err := CreateVindex(targetVindex, targetVindex, params, nil, nil)
 	if err != nil {
 		return 0
 	}

--- a/go/vt/vtgate/vindexes/hash.go
+++ b/go/vt/vtgate/vindexes/hash.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"strconv"
 
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -48,7 +49,7 @@ type Hash struct {
 }
 
 // NewHash creates a new Hash.
-func NewHash(name string, _ map[string]string) (Vindex, error) {
+func NewHash(name string, _ map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	return &Hash{name: name}, nil
 }
 

--- a/go/vt/vtgate/vindexes/hash_test.go
+++ b/go/vt/vtgate/vindexes/hash_test.go
@@ -31,7 +31,7 @@ import (
 var hash SingleColumn
 
 func init() {
-	hv, err := CreateVindex("hash", "nn", map[string]string{"Table": "t", "Column": "c"})
+	hv, err := CreateVindex("hash", "nn", map[string]string{"Table": "t", "Column": "c"}, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/go/vt/vtgate/vindexes/hybrid_test.go
+++ b/go/vt/vtgate/vindexes/hybrid_test.go
@@ -38,7 +38,6 @@ func TestHybridInfo(t *testing.T) {
 	assert.Equal(t, "etsy_hybrid_a_hash", hybridHashReverseThreshold.(*Hybrid).vindexA.String())
 	assert.Equal(t, "etsy_hybrid_b_reverse_bits", hybridHashReverseThreshold.(*Hybrid).vindexB.String())
 	assert.Equal(t, uint64(5), hybridHashReverseThreshold.(*Hybrid).threshold)
-	assert.Equal(t, map[string]SingleColumn{"etsy_hybrid": hybridHashReverseThreshold}, hybridVindexes)
 
 	hybridHashReverseFallback := createHybridWithFallback("hash", "reverse_bits", map[string]string{}, t)
 	assert.Equal(t, 1, hybridHashReverseFallback.Cost())
@@ -73,7 +72,6 @@ func TestHybridInfo(t *testing.T) {
 	assert.Equal(t, "etsy_hybrid_a_etsy_sqlite_lookup_unique", hybridSqliteHashFallback.(*Hybrid).vindexA.String())
 	assert.Equal(t, "etsy_hybrid_b_hash", hybridSqliteHashFallback.(*Hybrid).vindexB.String())
 	assert.Equal(t, uint64(0), hybridSqliteHashFallback.(*Hybrid).threshold)
-	assert.Equal(t, map[string]SingleColumn{"etsy_hybrid": hybridSqliteHashFallback}, hybridVindexes)
 }
 
 // Ensure that the Vindex correctly maps ids to destinations
@@ -204,7 +202,7 @@ func createHybridWithThreshold(vindexA string, vindexB string, threshold int, op
 	options["vindex_b"] = vindexB
 	options["threshold"] = strconv.Itoa(threshold)
 
-	l, err := CreateVindex("etsy_hybrid", "etsy_hybrid", options)
+	l, err := CreateVindex("etsy_hybrid", "etsy_hybrid", options, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,7 +214,7 @@ func createHybridWithFallback(vindexA string, vindexB string, options map[string
 	options["vindex_a"] = vindexA
 	options["vindex_b"] = vindexB
 
-	l, err := CreateVindex("etsy_hybrid", "etsy_hybrid", options)
+	l, err := CreateVindex("etsy_hybrid", "etsy_hybrid", options, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/vtgate/vindexes/lookup.go
+++ b/go/vt/vtgate/vindexes/lookup.go
@@ -24,6 +24,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 )
 
@@ -178,7 +179,7 @@ func (ln *LookupNonUnique) Query() (selQuery string, arguments []string) {
 //
 //	autocommit: setting this to "true" will cause inserts to upsert and deletes to be ignored.
 //	write_only: in this mode, Map functions return the full keyrange causing a full scatter.
-func NewLookup(name string, m map[string]string) (Vindex, error) {
+func NewLookup(name string, m map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	lookup := &LookupNonUnique{name: name}
 
 	cc, err := parseCommonConfig(m)
@@ -236,7 +237,7 @@ func (lu *LookupUnique) AllowBatch() bool {
 //
 //	autocommit: setting this to "true" will cause deletes to be ignored.
 //	write_only: in this mode, Map functions return the full keyrange causing a full scatter.
-func NewLookupUnique(name string, m map[string]string) (Vindex, error) {
+func NewLookupUnique(name string, m map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	lu := &LookupUnique{name: name}
 
 	cc, err := parseCommonConfig(m)

--- a/go/vt/vtgate/vindexes/lookup_hash.go
+++ b/go/vt/vtgate/vindexes/lookup_hash.go
@@ -26,6 +26,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 )
 
@@ -66,7 +67,7 @@ type LookupHash struct {
 //
 //	autocommit: setting this to "true" will cause inserts to upsert and deletes to be ignored.
 //	write_only: in this mode, Map functions return the full keyrange causing a full scatter.
-func NewLookupHash(name string, m map[string]string) (Vindex, error) {
+func NewLookupHash(name string, m map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	lh := &LookupHash{name: name}
 
 	cc, err := parseCommonConfig(m)
@@ -263,7 +264,7 @@ var _ LookupPlanable = (*LookupHashUnique)(nil)
 //
 //	autocommit: setting this to "true" will cause deletes to be ignored.
 //	write_only: in this mode, Map functions return the full keyrange causing a full scatter.
-func NewLookupHashUnique(name string, m map[string]string) (Vindex, error) {
+func NewLookupHashUnique(name string, m map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	lhu := &LookupHashUnique{name: name}
 
 	cc, err := parseCommonConfig(m)

--- a/go/vt/vtgate/vindexes/lookup_hash_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_test.go
@@ -45,7 +45,7 @@ func TestLookupHashNew(t *testing.T) {
 		"from":       "fromc",
 		"to":         "toc",
 		"write_only": "invalid",
-	})
+	}, nil)
 	want := "write_only value must be 'true' or 'false': 'invalid'"
 	if err == nil || err.Error() != want {
 		t.Errorf("Create(bad_scatter): %v, want %s", err, want)

--- a/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
@@ -40,7 +40,7 @@ func TestLookupHashUniqueNew(t *testing.T) {
 		"from":       "fromc",
 		"to":         "toc",
 		"write_only": "true",
-	})
+	}, nil)
 	l = vindex.(SingleColumn)
 	if want, got := l.(*LookupHashUnique).writeOnly, true; got != want {
 		t.Errorf("Create(lookup, false): %v, want %v", got, want)
@@ -51,7 +51,7 @@ func TestLookupHashUniqueNew(t *testing.T) {
 		"from":       "fromc",
 		"to":         "toc",
 		"write_only": "invalid",
-	})
+	}, nil)
 	want := "write_only value must be 'true' or 'false': 'invalid'"
 	if err == nil || err.Error() != want {
 		t.Errorf("Create(bad_scatter): %v, want %s", err, want)

--- a/go/vt/vtgate/vindexes/lookup_test.go
+++ b/go/vt/vtgate/vindexes/lookup_test.go
@@ -124,7 +124,7 @@ func TestLookupNonUniqueNew(t *testing.T) {
 		"from":       "fromc",
 		"to":         "toc",
 		"write_only": "invalid",
-	})
+	}, nil)
 	require.EqualError(t, err, "write_only value must be 'true' or 'false': 'invalid'")
 }
 
@@ -182,7 +182,7 @@ func TestLookupNonUniqueMapAutocommit(t *testing.T) {
 		"from":       "fromc",
 		"to":         "toc",
 		"autocommit": "true",
-	})
+	}, nil)
 	require.NoError(t, err)
 	lookupNonUnique := vindex.(SingleColumn)
 	vc := &vcursor{numRows: 2}
@@ -287,7 +287,7 @@ func TestLookupNonUniqueVerifyAutocommit(t *testing.T) {
 		"from":       "fromc",
 		"to":         "toc",
 		"autocommit": "true",
-	})
+	}, nil)
 	require.NoError(t, err)
 	lookupNonUnique := vindex.(SingleColumn)
 	vc := &vcursor{numRows: 1}
@@ -373,7 +373,7 @@ func TestLookupNonUniqueCreateAutocommit(t *testing.T) {
 		"from":       "from1,from2",
 		"to":         "toc",
 		"autocommit": "true",
-	})
+	}, nil)
 	require.NoError(t, err)
 	vc := &vcursor{}
 
@@ -438,7 +438,7 @@ func TestLookupNonUniqueDeleteAutocommit(t *testing.T) {
 		"from":       "fromc",
 		"to":         "toc",
 		"autocommit": "true",
-	})
+	}, nil)
 	vc := &vcursor{}
 
 	err := lookupNonUnique.(Lookup).Delete(context.Background(), vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}, {sqltypes.NewInt64(2)}}, []byte("test"))
@@ -526,7 +526,7 @@ func TestLookupNonUniqueCreateMultiShardAutocommit(t *testing.T) {
 		"from":                   "from1,from2",
 		"to":                     "toc",
 		"multi_shard_autocommit": "true",
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	vc := &vcursor{}
@@ -563,7 +563,7 @@ func createLookup(t *testing.T, name string, writeOnly bool) SingleColumn {
 		"from":       "fromc",
 		"to":         "toc",
 		"write_only": write,
-	})
+	}, nil)
 	require.NoError(t, err)
 	return l.(SingleColumn)
 }

--- a/go/vt/vtgate/vindexes/lookup_unicodeloosemd5_hash.go
+++ b/go/vt/vtgate/vindexes/lookup_unicodeloosemd5_hash.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 )
 
@@ -67,7 +68,7 @@ type LookupUnicodeLooseMD5Hash struct {
 //
 //	autocommit: setting this to "true" will cause inserts to upsert and deletes to be ignored.
 //	write_only: in this mode, Map functions return the full keyrange causing a full scatter.
-func NewLookupUnicodeLooseMD5Hash(name string, m map[string]string) (Vindex, error) {
+func NewLookupUnicodeLooseMD5Hash(name string, m map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	lh := &LookupUnicodeLooseMD5Hash{name: name}
 
 	cc, err := parseCommonConfig(m)
@@ -289,7 +290,7 @@ type LookupUnicodeLooseMD5HashUnique struct {
 //
 //	autocommit: setting this to "true" will cause deletes to be ignored.
 //	write_only: in this mode, Map functions return the full keyrange causing a full scatter.
-func NewLookupUnicodeLooseMD5HashUnique(name string, m map[string]string) (Vindex, error) {
+func NewLookupUnicodeLooseMD5HashUnique(name string, m map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	lhu := &LookupUnicodeLooseMD5HashUnique{name: name}
 
 	cc, err := parseCommonConfig(m)

--- a/go/vt/vtgate/vindexes/lookup_unicodeloosemd5_hash_test.go
+++ b/go/vt/vtgate/vindexes/lookup_unicodeloosemd5_hash_test.go
@@ -86,7 +86,7 @@ func TestLookupUnicodeLooseMD5HashMapAutocommit(t *testing.T) {
 		"to":         "toc",
 		"hash_from":  "true",
 		"autocommit": "true",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,7 +218,7 @@ func TestLookupUnicodeLooseMD5HashVerifyAutocommit(t *testing.T) {
 		"from":       "fromc",
 		"to":         "toc",
 		"autocommit": "true",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -303,7 +303,7 @@ func TestLookupUnicodeLooseMD5HashCreateAutocommit(t *testing.T) {
 		"from":       "from1,from2",
 		"to":         "toc",
 		"autocommit": "true",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -342,7 +342,7 @@ func TestLookupUnicodeLooseMD5HashCreateMultiShardAutocommit(t *testing.T) {
 		"from":                   "from1,from2",
 		"to":                     "toc",
 		"multi_shard_autocommit": "true",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -422,7 +422,7 @@ func TestLookupUnicodeLooseMD5HashDeleteAutocommit(t *testing.T) {
 		"from":       "fromc",
 		"to":         "toc",
 		"autocommit": "true",
-	})
+	}, nil)
 	vc := &vcursor{}
 
 	err := lookupNonUnique.(Lookup).Delete(context.Background(), vc, [][]sqltypes.Value{{sqltypes.NewInt64(10)}, {sqltypes.NewInt64(20)}}, []byte("\x16k@\xb4J\xbaK\xd6"))

--- a/go/vt/vtgate/vindexes/lookup_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_unique_test.go
@@ -41,7 +41,7 @@ func TestLookupUniqueNew(t *testing.T) {
 		"from":       "fromc",
 		"to":         "toc",
 		"write_only": "true",
-	})
+	}, nil)
 	l = vindex.(SingleColumn)
 	if want, got := l.(*LookupUnique).writeOnly, true; got != want {
 		t.Errorf("Create(lookup, false): %v, want %v", got, want)
@@ -52,7 +52,7 @@ func TestLookupUniqueNew(t *testing.T) {
 		"from":       "fromc",
 		"to":         "toc",
 		"write_only": "invalid",
-	})
+	}, nil)
 	want := "write_only value must be 'true' or 'false': 'invalid'"
 	if err == nil || err.Error() != want {
 		t.Errorf("Create(bad_scatter): %v, want %s", err, want)
@@ -159,7 +159,7 @@ func TestLookupUniqueCreate(t *testing.T) {
 		"from":       "from",
 		"to":         "toc",
 		"autocommit": "true",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/vtgate/vindexes/multicol.go
+++ b/go/vt/vtgate/vindexes/multicol.go
@@ -25,6 +25,7 @@ import (
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 )
@@ -47,7 +48,7 @@ const (
 )
 
 // NewMultiCol creates a new MultiCol.
-func NewMultiCol(name string, m map[string]string) (Vindex, error) {
+func NewMultiCol(name string, m map[string]string, ksVindexesSchemaInfo map[string]*vschemapb.Vindex) (Vindex, error) {
 	colCount, err := getColumnCount(m)
 	if err != nil {
 		return nil, err
@@ -56,7 +57,7 @@ func NewMultiCol(name string, m map[string]string) (Vindex, error) {
 	if err != nil {
 		return nil, err
 	}
-	columnVdx, vindexCost, err := getColumnVindex(m, colCount)
+	columnVdx, vindexCost, err := getColumnVindex(m, colCount, ksVindexesSchemaInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +154,7 @@ func init() {
 	Register("multicol", NewMultiCol)
 }
 
-func getColumnVindex(m map[string]string, colCount int) (map[int]Hashing, int, error) {
+func getColumnVindex(m map[string]string, colCount int, ksVindexesSchemaInfo map[string]*vschemapb.Vindex) (map[int]Hashing, int, error) {
 	var colVdxs []string
 	colVdxsStr, ok := m[paramColumnVindex]
 	if ok {
@@ -173,7 +174,7 @@ func getColumnVindex(m map[string]string, colCount int) (map[int]Hashing, int, e
 			}
 		}
 		// TODO: reuse vindex. avoid creating same vindex.
-		vdx, err := CreateVindex(selVdx, selVdx, m)
+		vdx, err := CreateVindex(selVdx, selVdx, m, ksVindexesSchemaInfo)
 		if err != nil {
 			return nil, 0, err
 		}

--- a/go/vt/vtgate/vindexes/multicol_test.go
+++ b/go/vt/vtgate/vindexes/multicol_test.go
@@ -31,7 +31,7 @@ import (
 func TestMultiColMisc(t *testing.T) {
 	vindex, err := CreateVindex("multicol", "multicol", map[string]string{
 		"column_count": "3",
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	multiColVdx, isMultiColVdx := vindex.(*MultiCol)
@@ -47,7 +47,7 @@ func TestMultiColMisc(t *testing.T) {
 func TestMultiColMap(t *testing.T) {
 	vindex, err := CreateVindex("multicol", "multicol", map[string]string{
 		"column_count": "3",
-	})
+	}, nil)
 	require.NoError(t, err)
 	mutiCol := vindex.(MultiColumn)
 

--- a/go/vt/vtgate/vindexes/null.go
+++ b/go/vt/vtgate/vindexes/null.go
@@ -22,6 +22,7 @@ import (
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 )
 
 var (
@@ -40,7 +41,7 @@ type Null struct {
 }
 
 // NewNull creates a new Null.
-func NewNull(name string, m map[string]string) (Vindex, error) {
+func NewNull(name string, m map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	return &Null{name: name}, nil
 }
 

--- a/go/vt/vtgate/vindexes/null_test.go
+++ b/go/vt/vtgate/vindexes/null_test.go
@@ -31,7 +31,7 @@ import (
 var null SingleColumn
 
 func init() {
-	hv, err := CreateVindex("null", "nn", map[string]string{"Table": "t", "Column": "c"})
+	hv, err := CreateVindex("null", "nn", map[string]string{"Table": "t", "Column": "c"}, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/go/vt/vtgate/vindexes/numeric.go
+++ b/go/vt/vtgate/vindexes/numeric.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -41,7 +42,7 @@ type Numeric struct {
 }
 
 // NewNumeric creates a Numeric vindex.
-func NewNumeric(name string, _ map[string]string) (Vindex, error) {
+func NewNumeric(name string, _ map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	return &Numeric{name: name}, nil
 }
 

--- a/go/vt/vtgate/vindexes/numeric_static_map.go
+++ b/go/vt/vtgate/vindexes/numeric_static_map.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"strconv"
 
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -51,7 +52,7 @@ func init() {
 }
 
 // NewNumericStaticMap creates a NumericStaticMap vindex.
-func NewNumericStaticMap(name string, params map[string]string) (Vindex, error) {
+func NewNumericStaticMap(name string, params map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	jsonPath, ok := params["json_path"]
 	if !ok {
 		return nil, errors.New("NumericStaticMap: Could not find `json_path` param in vschema")

--- a/go/vt/vtgate/vindexes/numeric_static_map_test.go
+++ b/go/vt/vtgate/vindexes/numeric_static_map_test.go
@@ -33,7 +33,7 @@ import (
 func createVindex() (SingleColumn, error) {
 	m := make(map[string]string)
 	m["json_path"] = "testdata/numeric_static_map_test.json"
-	vindex, err := CreateVindex("numeric_static_map", "numericStaticMap", m)
+	vindex, err := CreateVindex("numeric_static_map", "numericStaticMap", m, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/go/vt/vtgate/vindexes/numeric_test.go
+++ b/go/vt/vtgate/vindexes/numeric_test.go
@@ -31,7 +31,7 @@ import (
 var numeric SingleColumn
 
 func init() {
-	vindex, _ := CreateVindex("numeric", "num", nil)
+	vindex, _ := CreateVindex("numeric", "num", nil, nil)
 	numeric = vindex.(SingleColumn)
 }
 

--- a/go/vt/vtgate/vindexes/region_experimental.go
+++ b/go/vt/vtgate/vindexes/region_experimental.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -48,7 +49,7 @@ type RegionExperimental struct {
 // NewRegionExperimental creates a RegionExperimental vindex.
 // The supplied map requires all the fields of "consistent_lookup_unique".
 // Additionally, it requires a region_bytes argument whose value can be "1", or "2".
-func NewRegionExperimental(name string, m map[string]string) (Vindex, error) {
+func NewRegionExperimental(name string, m map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	rbs, ok := m["region_bytes"]
 	if !ok {
 		return nil, fmt.Errorf("region_experimental missing region_bytes param")

--- a/go/vt/vtgate/vindexes/region_experimental_test.go
+++ b/go/vt/vtgate/vindexes/region_experimental_test.go
@@ -125,7 +125,7 @@ func TestRegionExperimentalVerifyMulti(t *testing.T) {
 func TestRegionExperimentalCreateErrors(t *testing.T) {
 	_, err := createRegionVindex(t, "region_experimental", "f1,f2", 3)
 	assert.EqualError(t, err, "region_bits must be 1 or 2: 3")
-	_, err = CreateVindex("region_experimental", "region_experimental", nil)
+	_, err = CreateVindex("region_experimental", "region_experimental", nil, nil)
 	assert.EqualError(t, err, "region_experimental missing region_bytes param")
 }
 
@@ -135,5 +135,5 @@ func createRegionVindex(t *testing.T, name, from string, rb int) (Vindex, error)
 		"table":        "t",
 		"from":         from,
 		"to":           "toc",
-	})
+	}, nil)
 }

--- a/go/vt/vtgate/vindexes/region_json.go
+++ b/go/vt/vtgate/vindexes/region_json.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"strconv"
 
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -58,7 +59,7 @@ type RegionJSON struct {
 // The supplied map requires all the fields of "RegionExperimental".
 // Additionally, it requires a region_map argument representing the path to a json file
 // containing a map of country to region.
-func NewRegionJSON(name string, m map[string]string) (Vindex, error) {
+func NewRegionJSON(name string, m map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	rmPath := m["region_map"]
 	rmap := make(map[string]uint64)
 	data, err := os.ReadFile(rmPath)

--- a/go/vt/vtgate/vindexes/reverse_bits.go
+++ b/go/vt/vtgate/vindexes/reverse_bits.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"math/bits"
 
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -43,7 +44,7 @@ type ReverseBits struct {
 }
 
 // NewReverseBits creates a new ReverseBits.
-func NewReverseBits(name string, m map[string]string) (Vindex, error) {
+func NewReverseBits(name string, m map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	return &ReverseBits{name: name}, nil
 }
 

--- a/go/vt/vtgate/vindexes/reverse_bits_test.go
+++ b/go/vt/vtgate/vindexes/reverse_bits_test.go
@@ -31,7 +31,7 @@ import (
 var reverseBits SingleColumn
 
 func init() {
-	hv, err := CreateVindex("reverse_bits", "rr", map[string]string{"Table": "t", "Column": "c"})
+	hv, err := CreateVindex("reverse_bits", "rr", map[string]string{"Table": "t", "Column": "c"}, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/go/vt/vtgate/vindexes/sqlite_lookup.go
+++ b/go/vt/vtgate/vindexes/sqlite_lookup.go
@@ -29,6 +29,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/key"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 
 	_ "github.com/mattn/go-sqlite3" // sqlite driver
 )
@@ -81,7 +82,7 @@ type SqliteLookupUnique struct {
 //
 // As writes cannot be distributed across all vtgate machines, and writes must obtain
 // locks on the sqlite db, SQLite lookups are always read only
-func NewSqliteLookupUnique(name string, m map[string]string) (Vindex, error) {
+func NewSqliteLookupUnique(name string, m map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	slu := &SqliteLookupUnique{name: name}
 	slu.path = m["path"]
 	slu.table = m["table"]

--- a/go/vt/vtgate/vindexes/sqlite_lookup_unique_test.go
+++ b/go/vt/vtgate/vindexes/sqlite_lookup_unique_test.go
@@ -141,7 +141,7 @@ func createSqliteLookupUnique(t *testing.T) SingleColumn {
 		"from":       "id",
 		"to":         "ksid",
 		"cache_size": "100",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/vtgate/vindexes/unicodeloosemd5.go
+++ b/go/vt/vtgate/vindexes/unicodeloosemd5.go
@@ -23,6 +23,7 @@ import (
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 )
 
 var (
@@ -40,7 +41,7 @@ type UnicodeLooseMD5 struct {
 }
 
 // NewUnicodeLooseMD5 creates a new UnicodeLooseMD5.
-func NewUnicodeLooseMD5(name string, _ map[string]string) (Vindex, error) {
+func NewUnicodeLooseMD5(name string, _ map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	return &UnicodeLooseMD5{name: name}, nil
 }
 

--- a/go/vt/vtgate/vindexes/unicodeloosemd5_test.go
+++ b/go/vt/vtgate/vindexes/unicodeloosemd5_test.go
@@ -30,7 +30,7 @@ import (
 var charVindexMD5 SingleColumn
 
 func init() {
-	vindex, _ := CreateVindex("unicode_loose_md5", "utf8ch", nil)
+	vindex, _ := CreateVindex("unicode_loose_md5", "utf8ch", nil, nil)
 	charVindexMD5 = vindex.(SingleColumn)
 }
 

--- a/go/vt/vtgate/vindexes/unicodeloosexxhash.go
+++ b/go/vt/vtgate/vindexes/unicodeloosexxhash.go
@@ -23,6 +23,7 @@ import (
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 )
 
 var (
@@ -40,7 +41,7 @@ type UnicodeLooseXXHash struct {
 }
 
 // NewUnicodeLooseXXHash creates a new UnicodeLooseXXHash struct.
-func NewUnicodeLooseXXHash(name string, _ map[string]string) (Vindex, error) {
+func NewUnicodeLooseXXHash(name string, _ map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	return &UnicodeLooseXXHash{name: name}, nil
 }
 

--- a/go/vt/vtgate/vindexes/unicodeloosexxhash_test.go
+++ b/go/vt/vtgate/vindexes/unicodeloosexxhash_test.go
@@ -30,7 +30,7 @@ import (
 var charVindexXXHash SingleColumn
 
 func init() {
-	vindex, _ := CreateVindex("unicode_loose_xxhash", "utf8ch", nil)
+	vindex, _ := CreateVindex("unicode_loose_xxhash", "utf8ch", nil, nil)
 	charVindexXXHash = vindex.(SingleColumn)
 }
 

--- a/go/vt/vtgate/vindexes/vindex_test.go
+++ b/go/vt/vtgate/vindexes/vindex_test.go
@@ -40,7 +40,7 @@ func TestVindexMap(t *testing.T) {
 	}
 	assert.Equal(t, want, got)
 
-	hash, err := CreateVindex("hash", "hash", nil)
+	hash, err := CreateVindex("hash", "hash", nil, nil)
 	assert.NoError(t, err)
 	got, err = Map(context.Background(), hash, nil, [][]sqltypes.Value{{
 		sqltypes.NewInt64(1),
@@ -66,7 +66,7 @@ func TestVindexVerify(t *testing.T) {
 	want := []bool{true}
 	assert.Equal(t, want, got)
 
-	hash, err := CreateVindex("hash", "hash", nil)
+	hash, err := CreateVindex("hash", "hash", nil, nil)
 	assert.NoError(t, err)
 	got, err = Verify(context.Background(), hash, nil, [][]sqltypes.Value{{
 		sqltypes.NewInt64(1),

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -250,7 +250,7 @@ func buildKeyspaces(source *vschemapb.SrvVSchema, vschema *VSchema) {
 func buildTables(ks *vschemapb.Keyspace, vschema *VSchema, ksvschema *KeyspaceSchema) error {
 	keyspace := ksvschema.Keyspace
 	for vname, vindexInfo := range ks.Vindexes {
-		vindex, err := CreateVindex(vindexInfo.Type, vname, vindexInfo.Params)
+		vindex, err := CreateVindex(vindexInfo.Type, vname, vindexInfo.Params, ks.Vindexes)
 		if err != nil {
 			return err
 		}

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -58,7 +58,7 @@ func (*cheapVindex) Map(ctx context.Context, vcursor VCursor, ids []sqltypes.Val
 	return nil, nil
 }
 
-func NewCheapVindex(name string, params map[string]string) (Vindex, error) {
+func NewCheapVindex(name string, params map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	return &cheapVindex{name: name, Params: params}, nil
 }
 
@@ -81,7 +81,7 @@ func (*stFU) Map(ctx context.Context, vcursor VCursor, ids []sqltypes.Value) ([]
 	return nil, nil
 }
 
-func NewSTFU(name string, params map[string]string) (Vindex, error) {
+func NewSTFU(name string, params map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	return &stFU{name: name, Params: params}, nil
 }
 
@@ -104,7 +104,7 @@ func (*stFN) Map(ctx context.Context, vcursor VCursor, ids []sqltypes.Value) ([]
 	return nil, nil
 }
 
-func NewSTFN(name string, params map[string]string) (Vindex, error) {
+func NewSTFN(name string, params map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	return &stFN{name: name, Params: params}, nil
 }
 
@@ -132,7 +132,7 @@ func (*stLN) Update(context.Context, VCursor, []sqltypes.Value, []byte, []sqltyp
 	return nil
 }
 
-func NewSTLN(name string, params map[string]string) (Vindex, error) {
+func NewSTLN(name string, params map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	return &stLN{name: name, Params: params}, nil
 }
 
@@ -161,7 +161,7 @@ func (*stLU) Update(context.Context, VCursor, []sqltypes.Value, []byte, []sqltyp
 	return nil
 }
 
-func NewSTLU(name string, params map[string]string) (Vindex, error) {
+func NewSTLU(name string, params map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	return &stLU{name: name, Params: params}, nil
 }
 
@@ -199,7 +199,7 @@ func (v *stLO) SetOwnerInfo(keyspace, table string, cols []sqlparser.IdentifierC
 	return nil
 }
 
-func NewSTLO(name string, _ map[string]string) (Vindex, error) {
+func NewSTLO(name string, _ map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	return &stLO{name: name}, nil
 }
 
@@ -224,7 +224,7 @@ func (*mcFU) Map(ctx context.Context, vcursor VCursor, rowsColValues [][]sqltype
 }
 func (*mcFU) PartialVindex() bool { return false }
 
-func NewMCFU(name string, params map[string]string) (Vindex, error) {
+func NewMCFU(name string, params map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	return &mcFU{name: name, Params: params}, nil
 }
 
@@ -2568,7 +2568,7 @@ func TestVSchemaJSON(t *testing.T) {
 		"from":  "f",
 		"table": "t",
 		"to":    "2",
-	})
+	}, nil)
 	in := map[string]*KeyspaceSchema{
 		"unsharded": {
 			Keyspace: &Keyspace{

--- a/go/vt/vtgate/vindexes/xxhash.go
+++ b/go/vt/vtgate/vindexes/xxhash.go
@@ -25,6 +25,7 @@ import (
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 )
 
 var (
@@ -39,7 +40,7 @@ type XXHash struct {
 }
 
 // NewXXHash creates a new XXHash.
-func NewXXHash(name string, _ map[string]string) (Vindex, error) {
+func NewXXHash(name string, _ map[string]string, _ map[string]*vschemapb.Vindex) (Vindex, error) {
 	return &XXHash{name: name}, nil
 }
 

--- a/go/vt/vtgate/vindexes/xxhash_test.go
+++ b/go/vt/vtgate/vindexes/xxhash_test.go
@@ -33,7 +33,7 @@ import (
 var xxHash SingleColumn
 
 func init() {
-	hv, err := CreateVindex("xxhash", "xxhash_name", map[string]string{"Table": "t", "Column": "c"})
+	hv, err := CreateVindex("xxhash", "xxhash_name", map[string]string{"Table": "t", "Column": "c"}, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/go/vt/vttablet/tabletserver/vstreamer/local_vschema.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/local_vschema.go
@@ -62,7 +62,12 @@ func (lvs *localVSchema) FindOrCreateVindex(qualifiedName string) (vindexes.Vind
 	if keyspace != "" {
 		return nil, fmt.Errorf("vindex %v not found", qualifiedName)
 	}
-	return vindexes.CreateVindex(name, name, map[string]string{})
+
+	// TODO This call to CreateVindex only supports the subset of vindexes that take empty parameters.
+	// None of this subset of vindexes needs access to other vindexes' vschema configs.
+	// If they do in the future, pass in the ksVindexesSchemaInfo argument
+	// For now, nil is passed.
+	return vindexes.CreateVindex(name, name, map[string]string{}, nil)
 }
 
 func (lvs *localVSchema) findTable(tablename string) (*vindexes.Table, error) {

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder_test.go
@@ -597,7 +597,7 @@ func TestPlanBuilderFilterComparison(t *testing.T) {
 			Type: sqltypes.VarBinary,
 		}},
 	}
-	hashVindex, err := vindexes.NewHash("hash", nil)
+	hashVindex, err := vindexes.NewHash("hash", nil, nil)
 	require.NoError(t, err)
 	testcases := []struct {
 		name       string

--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -493,7 +493,10 @@ func (wr *Wrangler) prepareCreateLookup(ctx context.Context, keyspace string, sp
 	// it will need to match this vindex exactly, including the write_only setting.
 	vindex.Params["write_only"] = "true"
 	// See if we can create the vindex without errors.
-	if _, err := vindexes.CreateVindex(vindex.Type, vindexName, vindex.Params); err != nil {
+	// TODO: If a lookup vindex ever needs access other vindexes' vschema config data,
+	// pass in the ksVindexesSchemaInfo and ksVindexes arguments
+	// For now, nil is passed because the lookup vindexes don't need this.
+	if _, err := vindexes.CreateVindex(vindex.Type, vindexName, vindex.Params, nil); err != nil {
 		return nil, nil, nil, err
 	}
 


### PR DESCRIPTION
## Context

A [previous commit](https://github.com/etsy/vitess/commit/a9fdeb467d6088c87d52c0d5f251ba7fa138b7be) added a new Multisharded vindex type. The Multisharded vindex receives two record columns -- a type_id, which corresponds to a shardifier type and its corresponding hybrid vindex, and the identifier id. The Multisharded vindex uses the hybrid vindex corresponding to the type_id to resolve the identifier id to a key range. 

However, the approach of the previous commit relied on an incorrect assumption that vindexes would be created in the order that they are defined in the vschema.json file. Specifically, the previous approach stored [a pointer to each hybrid vindex](https://github.com/etsy/vitess/blob/a9fdeb467d6088c87d52c0d5f251ba7fa138b7be/go/vt/vtgate/vindexes/hybrid.go#L89) as the vindex was created, and [validated](https://github.com/etsy/vitess/blob/a9fdeb467d6088c87d52c0d5f251ba7fa138b7be/go/vt/vtgate/vindexes/multisharded.go#L64) that all hybrid vindexes that the Multisharded vindex depended on (I'll refer to them as the Multisharded vindex's "subvindexes") existed at the time the Multisharded vindex was created. As it turns out, the order in which vindexes are created is non-deterministic. That's because Vitess [unmarshals the vschema.json into a map](https://github.com/etsy/vitess/blob/a9fdeb467d6088c87d52c0d5f251ba7fa138b7be/go/vt/proto/vschema/vschema.pb.go#L156), which is [unordered in Golang](https://go.dev/blog/maps#:~:text=When%20iterating%20over%20a%20map%20with%20a%20range%20loop%2C%20the%20iteration%20order%20is%20not%20specified%20and%20is%20not%20guaranteed%20to%20be%20the%20same%20from%20one%20iteration%20to%20the%20next.).

As a result, the `No hybrid vindex [...] has been defined` error is sometimes thrown when a vschema containing a Multisharded vindex is loaded.

## This PR's Changes

This PR eliminates the Multisharded vindex's dependency on vschema creation order. It does so by [passing in a vschemapb.Keyspace.Vindex object](https://github.com/etsy/vitess/blob/a9fdeb467d6088c87d52c0d5f251ba7fa138b7be/go/vt/vtgate/vindexes/vschema.go#L253), containing keyspace-level vindex vschema config info, to each vindex's [NewVindexFunc](https://github.com/etsy/vitess/blob/93ff149cc43d36958e7f5d6504c434b98b9ad00a/go/vt/vtgate/vindexes/vindex.go#L189) when each vindex defined in vschema.json is created.

The new `ksVindexesSchemaInfo` parameter allows the `NewMultiSharded` function to access vschema config data [necessary to create the subvindexes it depends on](https://github.com/etsy/vitess/blob/93ff149cc43d36958e7f5d6504c434b98b9ad00a/go/vt/vtgate/vindexes/multisharded.go#L74) when a Multisharded vindex is created. 

Currently, this new parameter is only used by the Multisharded vindex type. This PR contains changes across many files because each vindex's `NewVindexFunc` is updated to support an additional parameter, and callsites for `CreateVindex` and implementations of `NewVindexFunc` must be updated to pass in the new `ksVindexesSchemaInfo` argument. In most cases, `nil` is passed in for non-Multisharded vindexes.

## Risks

1. Compared to the previous approach, the current approach is more memory intensive, because Hybrid vindex instances will be created multiple times: first, when they are created as a result of being independently defined in the vschema.json, and again when they are created by any Multisharded vindex(es). However, there are precedents for this pattern in the [hybrid vindex](https://github.com/etsy/vitess/blob/a9fdeb467d6088c87d52c0d5f251ba7fa138b7be/go/vt/vtgate/vindexes/hybrid.go#L77) and the [multicol vindex](https://github.com/etsy/vitess/blob/a9fdeb467d6088c87d52c0d5f251ba7fa138b7be/go/vt/vtgate/vindexes/multicol.go#L176), both of which create multiple hash vindex instances with identical configurations.

2. It only passes a non-nil value for the `ksVindexesSchemaInfo` argument when `CreateVindex` is called within the BuildTables method. If `CreateVindex` is ever called with `NewMultiSharded` elsewhere, the function would error. I searched the codebase for references to `CreateVindex`, and didn't find any other callsites where it would be called with `NewMultiSharded`.

3. Currently, we upgrade Vitess by rebasing our patches on top of the upgraded source. This PR has a large blast radius, which could make it difficult to resolve merge conflicts and ensure the patched logic is safely applied to any updates to vindex logic in the source. h/t @ellayarmogray for pointing this out.

## Alternatives considered

### 1. Passing in a pointer to created vindex instances in addition to the vschema info 

@jmchen28 This is the initial approach we were aiming for after our pairing session.

When vindexes from the vschema are created, they are stored in the [ksvschema.Vindexes](
https://github.com/etsy/vitess/blob/a9fdeb467d6088c87d52c0d5f251ba7fa138b7be/go/vt/vtgate/vindexes/vschema.go#L266) struct. We could pass this struct, in addition to the vschema info, into NewVindexFunc.

This would allow us to do the following:
- In the NewVindexFunc, validate that all the subvindexes it needs actually exist in the vschema. This way, we can be confident that they will be created eventually. However, do not validate that instances of subvindexes have been created.
- When the Multisharded vindex's methods that rely on subvindex instances are called, access the subvindex instances via `ksvschema.Vindexes`.

I didn't go this route because I wasn't able to validate that all calls to Multisharded methods that rely on subvindex instances (`Map`, `Verify`, `Cost`, `IsUnique`, `NeedsVCursor`) will be called _after_ all vindexes defined in vschema.json are loaded. It felt safer to guarantee access to subvindex instances when a Multisharded vindex is created.

I considered adding logic in each of the Multisharded methods that rely on subvindex instances to check if the instance already existed and to create (and store a pointer to it on the Multisharded struct) the subvindex if the it did not already exist. However, this would require updating the Vindex interface so that `Cost`, `IsUnique`, and `NeedsVCursor` also returned an `error` (since `CreateVindex` may return an error) and handling that error. I didn't feel confident in my familiarity with the Vitess codebase to safely make this update and handle these errors.

### 2. Passing in subvindex configs as a "param" value for the multisharded vindex in vschema.json. 

An example of this would be:
```
        "etsy_multisharded_hybrid": {
            "type": "etsy_multisharded_hybrid",
            "params": {
                "type_id_to_vindex": "{\"2\":\"etsy_shard_hybrid_facebook_account\",\"30\":\"etsy_shard_hybrid_shop\"}",
                "subvindexes": "{\"etsy_shard_hybrid_shop\":\"params\": {\"cache_size\": \"2000\",\"from\": \"shop_id\",\"path\": \"dbindex.db\",\"table\": \"shops_index\",\"threshold\": \"123",\"to\": \"ksid\",\"vindex_a\": \"etsy_sqlite_lookup_unique\",\"vindex_b\": \"hash\"}, \"etsy_shard_hybrid_user\":\"params\": {\"cache_size\": \"2000\",\"from\": \"user_id\",\"path\": \"dbindex.db\",\"table\": \"shops_index\",\"threshold\": \"1123\",\"to\": \"ksid\",\"vindex_a\": \"etsy_sqlite_lookup_unique\",\"vindex_b\": \"hash\"}}"
            }
        }
```

This approach would allow us to avoid passing in an extra argument to the NewVindexFunc, but it would make the vschema.json verbose, especially because the `"params":` key currently only supports string values. And the Multisharded vindex would still create duplicate vindexes.

### 3. When the vschema.json is loaded, sort the vindex configs so they are loaded in a predictable way.

One option is to sort the vindex configs alphabetically in [BuildTables](https://github.com/etsy/vitess/blob/a9fdeb467d6088c87d52c0d5f251ba7fa138b7be/go/vt/vtgate/vindexes/vschema.go#L252), and ensure that Multisharded vindexes are defined alphabetically after any of their subvindexes in vschema.json.

This approach would be viable and low-effort, but it felt a little hacky. We'd need to append something like `z_` to each multisharded vindex name in vschema.json to ensure it comes alphabetically behind its subvindexes.

This might be a good approach if we are limited in time.

### 4. Use [json schema references](https://niem.github.io/json/reference/json-schema/references/) to cross reference the configs for Hybrid vindexes in the configs for Multisharded vindexes
This would make the vschema.json less verbose, but it would require us to update Vitess to be able to parse json references, which seemed more complex than the Vitess updates in the current approach. The Multisharded vindex would still create duplicate vindexes.

We also had some (initial, untested) performance concerns around parsing json schema references upon loading a vschema.json file.

## Testing

- Updated the Multisharded vindex's unit tests
- In etsy-vitess-sandbox, tested loading a vschema with a Multisharded vindex and reading and writing records to a multisharded table.
- Confirmed all unit tests under the `go/vt/vtgate/{engine|planbuilder|semantics|vindexes}` directories pass.  
    - This PR also has minor changes to files under `go/vt/wrangler` and `go/vt/vttablet/tabletserver/vstreamer` but I ran into errors related to mysql infrastructure dependencies not being set up in the testing environment. Based on [this doc](https://docs.google.com/document/d/1Pa7KWxmRtgud9ugt8D0mv5LZUhihOlefvBoMlmzjIuI/edit#heading=h.xgl98b6fomy0), it doesn't look like we have the ability to run all unit test without opening a PR in the planet scale repo.)

I didn't repeat performance testing, which was done when the Multisharded vindex was initially added, since our perf testing approach focused on query routing, and this PR doesn't change much at the query routing phase (just at the phase when the vschema is loaded).

## Related docs
- Brainstorming doc/notes from pairing with @jmchen28 on this specific issue: https://docs.google.com/document/d/1K7cVhGslNdpiViP75uKJ5zw5CIvQg37BFcO9L3KUEs4/edit#heading=h.7ihph5aaersz
- @wsung-asong's initial investigation into creating a multisharded vindex: https://docs.google.com/document/d/1VOi6xEgkeC69soahgdEp7zuC8E64xQSVm_NGTN0MnCk/
