### PR TITLE
[DAP-5348] Retry instantiating Vindex if subvindex dependencies have not yet been loaded on first attempt.

### DIFF
--- a/go/vt/vtgate/vindexes/multisharded.go
+++ b/go/vt/vtgate/vindexes/multisharded.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
@@ -33,12 +34,12 @@ func init() {
 }
 
 type MissingSubvindexError struct {
-	MissingSubvindex string
-	Method           string
+	MissingSubvindexes []string
+	Method             string
 }
 
 func (e *MissingSubvindexError) Error() string {
-	return fmt.Sprintf("%s: No hybrid vindex named %s has been defined", e.Method, e.MissingSubvindex)
+	return fmt.Sprintf("%s: The following subvindexes have not been defined: %s", e.Method, strings.Join(e.MissingSubvindexes, ", "))
 }
 
 // MultiSharded defines a multicolumn vindex that resolves a provided
@@ -67,13 +68,18 @@ func NewMultiSharded(name string, m map[string]string) (Vindex, error) {
 	}
 
 	subvindexes := make(map[string]SingleColumn)
+	missingSubvindexes := []string{}
 	for _, vindexName := range typeIdToSubvindexName {
-		// Only hybrid vindexes instantiated before this vindex will be avaiable in `hybridVindexes`.
+		// Only hybrid vindexes instantiated before this vindex will be available in `hybridVindexes`.
 		if _, ok := hybridVindexes[vindexName]; ok {
 			subvindexes[vindexName] = hybridVindexes[vindexName]
 		} else {
-			return nil, &MissingSubvindexError{MissingSubvindex: vindexName, Method: "Multisharded.NewMultiSharded"}
+			missingSubvindexes = append(missingSubvindexes, vindexName)
 		}
+	}
+
+	if len(missingSubvindexes) > 0 {
+		return nil, &MissingSubvindexError{MissingSubvindexes: missingSubvindexes, Method: "Multisharded.NewMultiSharded"}
 	}
 
 	return &MultiSharded{

--- a/go/vt/vtgate/vindexes/multisharded_test.go
+++ b/go/vt/vtgate/vindexes/multisharded_test.go
@@ -81,12 +81,18 @@ func TestMultiShardedCreation(t *testing.T) {
 
 func TestMultiShardedCreationWithNonexistantSubvindex(t *testing.T) {
 	hybridVindexes = map[string]SingleColumn{
-		"etsy_hybrid_DNE":  &HybridStub{},
+		"etsy_hybrid_user": &HybridStub{},
 		"etsy_hybrid_shop": &HybridStub{},
 	}
 
+	expectedMissingSubvindexes := map[string]bool{"etsy_hybrid_DNE": true, "etsy_hybrid_DNE_2": true}
+	expectedMissingSubvindexesSlice := []string{}
+	for expectedSubvindex := range expectedMissingSubvindexes {
+		expectedMissingSubvindexesSlice = append(expectedMissingSubvindexesSlice, expectedSubvindex)
+	}
+
 	params := map[string]string{
-		"type_id_to_vindex": `{"1":"etsy_hybrid_user", "2":"etsy_hybrid_shop"}`,
+		"type_id_to_vindex": `{"1":"etsy_hybrid_DNE", "2":"etsy_hybrid_shop", "3":"etsy_hybrid_DNE_2"}`,
 	}
 
 	expectedName := "multisharded_test"
@@ -98,6 +104,23 @@ func TestMultiShardedCreationWithNonexistantSubvindex(t *testing.T) {
 
 	if _, ok := err.(*MissingSubvindexError); !ok {
 		t.Errorf("Expected MissingSubvindexError from multisharded.NewMultiSharded, got %s", err.Error())
+	}
+
+	if len(expectedMissingSubvindexes) != len(err.(*MissingSubvindexError).MissingSubvindexes) {
+		t.Errorf(
+			"Got unexpected value for MissingSubvindexError.MissingSubvindexes. Expected: %v, Got: %v",
+			expectedMissingSubvindexesSlice,
+			err.(*MissingSubvindexError).MissingSubvindexes)
+	}
+
+	for _, subvindex := range err.(*MissingSubvindexError).MissingSubvindexes {
+		if _, ok := expectedMissingSubvindexes[subvindex]; !ok {
+			t.Errorf(
+				"Got unexpected value for MissingSubvindexError.MissingSubvindexes. Expected: %v, Got: %v",
+				expectedMissingSubvindexesSlice,
+				err.(*MissingSubvindexError).MissingSubvindexes)
+
+		}
 	}
 }
 

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -614,6 +614,7 @@ func TestVSchemaNoRetryIfSubvindexNotInVSchema(t *testing.T) {
 
 func TestVSchemaRetryVindexDependsOnItself(t *testing.T) {
 	stfudName := "stfud"
+	stfudVindexes = map[string]Vindex{}
 
 	schema := vschemapb.SrvVSchema{
 		Keyspaces: map[string]*vschemapb.Keyspace{
@@ -694,10 +695,6 @@ func TestVSchemaRetryVindexWithNonRetryableError(t *testing.T) {
 					},
 					stfueName2: {
 						Type:   "stfue",
-						Params: map[string]string{},
-					},
-					"foobar": {
-						Type:   "stfu",
 						Params: map[string]string{},
 					},
 				},


### PR DESCRIPTION
## Description

This PR updates the logic in [`BuildTables`](https://github.com/etsy/vitess/blob/swu-multisharded-retry/go/vt/vtgate/vindexes/vschema.go#L250) that loads vindexes from a keyspace's VSchema to behave as follows:
- BuildTables() will retry creating vindexes that initially failed to be created due to missing subvindexes that the failed vindex depends on. 
- Failed vindexes are retried after all vindexes defined in the vschema for a keyspace have been attempted to be created once.
- A vindex is retried exactly once, and only if it fails with a `MissingSubvindexError`.

Subvindexes are stored in the package-level [HybridVindexes](https://github.com/etsy/vitess/blob/main/go/vt/vtgate/vindexes/hybrid.go#L31) map.

The purpose of this change is to allow the MultiSharded vindex to access and reference Hybrid vindex dependencies that are defined in the same vschema.json for a keyspace. Because vindexes within vschema.json are loaded in nondeterministic order, a retry is required to ensure that Hybrid subvindexes are created before the dependent Multisharded vindex.

More context and a previous alternative implementation is available a previous PR: https://github.com/etsy/vitess/pull/24

## Testing
Unit tests are updated and pass
All unit tests within the `go/vtgate/vindexes` subdirectory pass
Manual testing in `etsy-vitess-sandbox`:
- Successful execution of insert/upsert/delete statements for a multisharded table that takes 2 hybrid subvindexes. The records I tested with had different permutations of being below or above the hybrid subvindex thresholds. In the case of a hybrid subvindex that had [no threshold](https://github.com/etsy/vitess/blob/main/go/vt/vtgate/vindexes/hybrid.go#L58), I used pkids that existed in the hybrid vindex's associated sqlite index table and outside of it, respectively.
- Execution of a script that ran `vtctl_etsy ApplyVSchema` 1000 times successfully, to confirm that no errors occurred when creating the Multisharded vindex due to vindex loading order.